### PR TITLE
Masked channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ source setup.sh
 
 An example can be found in ```tests/make_tensor.py -o test_tensor.hdf5```. 
 
+### Sparse tensor
+By setting `sparse=True` in the `TensorWriter` constructor the tensor is stored in the sparse representation. 
+This is useful when working with a sparse tensor, e.g. having many bins/processes/systematics where each bin/process/systematic only contributes to a small number of bins/processes/systematics. 
+This is often the case in the standard profile likelihood unfolding. 
+
 ### Symmetrization
 By default, systematic variations are asymmetric. 
 However, defining only symmetric variations can be beneficial as a fully symmetric tensor has reduced memory consumption, simplifications in the likelihood function in the fit, and is usually numerically more stable. 
@@ -79,6 +84,12 @@ Different symmetrization options are supported:
  * "linear": TBD
  * "quadratic": TBD
 If a systematic variation is added by providing a single histogram, the variation is mirrored. 
+
+### Masked channels
+Masked channels can be added that don't contribute to the likelihood but are evaluated as any other channel. 
+This is done by defining `masked=True` in the `tensorwriter` `add_channel` or `add_process` functions. 
+(Pseudo) Data histograms for masked channels are not supported.
+This is useful for example to compute unfolded (differential) cross sections and their uncertainties, including global impacts, taking into account all nuisance parameters that affect these channels.
 
 ## Run the fit
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ If a systematic variation is added by providing a single histogram, the variatio
 
 ### Masked channels
 Masked channels can be added that don't contribute to the likelihood but are evaluated as any other channel. 
-This is done by defining `masked=True` in the `tensorwriter` `add_channel` or `add_process` functions. 
+This is done by defining `masked=True` in the `tensorwriter` `add_channel` function. 
 (Pseudo) Data histograms for masked channels are not supported.
 This is useful for example to compute unfolded (differential) cross sections and their uncertainties, including global impacts, taking into account all nuisance parameters that affect these channels.
 

--- a/bin/combinetf2_fit.py
+++ b/bin/combinetf2_fit.py
@@ -27,6 +27,12 @@ def make_parser():
     parser.add_argument(
         "--noColorLogger", action="store_true", help="Do not use logging with colors"
     )
+    parser.add_argument(
+        "--eager",
+        action="store_true",
+        default=False,
+        help="Run tensorflow in eager mode (for debugging)",
+    )
     parser.add_argument("filename", help="filename of the main hdf5 input")
     parser.add_argument("-o", "--output", default="./", help="output directory")
     parser.add_argument("--outname", default="fitresults.hdf5", help="output file name")
@@ -516,6 +522,9 @@ def fit(args, fitter, ws, dofit=True):
 def main():
     start_time = time.time()
     args = make_parser()
+
+    if args.eager:
+        tf.config.run_functions_eagerly(True)
 
     global logger
     logger = logging.setup_logger(__file__, args.verbose, args.noColorLogger)

--- a/bin/combinetf2_fit.py
+++ b/bin/combinetf2_fit.py
@@ -267,24 +267,26 @@ def save_hists(args, fitter, ws, prefit=True):
 
     for p in args.project:
         channel = p[0]
-        axes = p[1:]
+        axes_names = p[1:]
+        channel_info = fitter.indata.channel_info[channel]
+        channel_axes = channel_info["axes"]
+
         print(f"Save projection for channel {channel} - inclusive")
 
         exp, aux = fitter.expected_events_projection(
             channel=channel,
-            axes=axes,
+            axes=axes_names,
             inclusive=True,
             compute_variance=args.computeHistErrors,
             compute_cov=args.computeHistCov,
             compute_chi2=not args.noChi2,
             compute_global_impacts=args.computeHistImpacts and not prefit,
+            masked=channel_info["masked"],
         )
-
-        channel_axes = fitter.indata.channel_info[channel]["axes"]
 
         ws.add_expected_projection_hists(
             channel,
-            axes,
+            axes_names,
             channel_axes,
             exp,
             var=aux[0],
@@ -301,14 +303,15 @@ def save_hists(args, fitter, ws, prefit=True):
 
             exp, aux = fitter.expected_events_projection(
                 channel=channel,
-                axes=axes,
+                axes=axes_names,
                 inclusive=False,
                 compute_variance=args.computeHistErrors,
+                masked=channel_info["masked"],
             )
 
             ws.add_expected_projection_hists(
                 channel,
-                axes,
+                axes_names,
                 channel_axes,
                 exp,
                 var=aux[0],

--- a/bin/combinetf2_plot_hists_cov.py
+++ b/bin/combinetf2_plot_hists_cov.py
@@ -71,7 +71,7 @@ def parseArgs():
     )
     parser.add_argument(
         "--subtitle",
-        default=None,
+        default="",
         type=str,
         help="Subtitle to be printed after title",
     )

--- a/bin/combinetf2_plot_hists_uncertainties.py
+++ b/bin/combinetf2_plot_hists_uncertainties.py
@@ -94,7 +94,7 @@ def parseArgs():
     )
     parser.add_argument(
         "--subtitle",
-        default=None,
+        default="",
         type=str,
         help="Subtitle to be printed after title",
     )

--- a/bin/combinetf2_plot_inputdata.py
+++ b/bin/combinetf2_plot_inputdata.py
@@ -586,7 +586,11 @@ def main():
             hists_syst_up = []
 
         # setup data histogram
-        if args.noData or args.splitByProcess:
+        if (
+            args.noData
+            or args.splitByProcess
+            or channel not in debug.data_obs_hists.keys()
+        ):
             hist_data = None
         else:
             hist_data_tmp = debug.data_obs_hists[channel]

--- a/bin/combinetf2_plot_likelihood_scan.py
+++ b/bin/combinetf2_plot_likelihood_scan.py
@@ -78,7 +78,7 @@ def parseArgs():
     )
     parser.add_argument(
         "--subtitle",
-        default=None,
+        default="",
         type=str,
         help="Subtitle to be printed after title",
     )

--- a/bin/combinetf2_plot_likelihood_scan2D.py
+++ b/bin/combinetf2_plot_likelihood_scan2D.py
@@ -79,7 +79,7 @@ def parseArgs():
     )
     parser.add_argument(
         "--subtitle",
-        default=None,
+        default="",
         type=str,
         help="Subtitle to be printed after title",
     )

--- a/bin/combinetf2_plot_pulls_and_impacts.py
+++ b/bin/combinetf2_plot_pulls_and_impacts.py
@@ -651,7 +651,7 @@ def parseArgs():
     )
     parser.add_argument(
         "--subtitle",
-        default=None,
+        default="",
         type=str,
         help="Subtitle to be printed after title",
     )

--- a/bin/combinetf2_print_impacts.py
+++ b/bin/combinetf2_print_impacts.py
@@ -59,10 +59,11 @@ def printImpacts(args, fitresult, poi):
         labels = labels[order]
         impacts = impacts[order]
 
+    nround = 5
     if args.asymImpacts:
-        fimpact = lambda x: f"{round(max(x)*100, 2)} / {round(min(x)*100, 2)}"
+        fimpact = lambda x: f"{round(max(x)*100, nround)} / {round(min(x)*100, nround)}"
     else:
-        fimpact = lambda x: round(x * 100, 2)
+        fimpact = lambda x: round(x * 100, nround)
 
     if args.nuisance:
         if args.nuisance not in labels:

--- a/combinetf2/debugdata.py
+++ b/combinetf2/debugdata.py
@@ -32,10 +32,11 @@ class FitDebugData:
             else:
                 shape_logk = [*shape, self.indata.nproc, 2, self.indata.nsyst]
 
-            data_obs_hist = hist.Hist(*axes, name=f"{channel}_data_obs")
-            data_obs_hist.values()[...] = memoryview(
-                tf.reshape(self.indata.data_obs[ibin:stop], shape)
-            )
+            if not info["masked"]:
+                data_obs_hist = hist.Hist(*axes, name=f"{channel}_data_obs")
+                data_obs_hist.values()[...] = memoryview(
+                    tf.reshape(self.indata.data_obs[ibin:stop], shape)
+                )
 
             nominal_hist = hist.Hist(*axes, self.axis_procs, name=f"{channel}_nominal")
             nominal_hist.values()[...] = memoryview(
@@ -85,7 +86,8 @@ class FitDebugData:
                 nonzero, axis=tuple(range(len(axes)))
             )
 
-            self.data_obs_hists[channel] = data_obs_hist
+            if not info["masked"]:
+                self.data_obs_hists[channel] = data_obs_hist
             self.nominal_hists[channel] = nominal_hist
             self.syst_hists[channel] = syst_hist
             self.syst_active_hists[channel] = syst_active_hist

--- a/combinetf2/h5pyutils.py
+++ b/combinetf2/h5pyutils.py
@@ -82,27 +82,3 @@ def writeSparse(indices, values, dense_shape, h5group, outname, maxChunkBytes=10
     outgroup.attrs["dense_shape"] = np.array(dense_shape, dtype="int64")
 
     return nbytes
-
-
-def simple_sparse_slice0end(in_sparse, end):
-    """
-    Slice a tf.sparse.SparseTensor along axis 0 starting 0 to the 'end'.
-    """
-
-    # Convert dense_shape, indices, and values to tensors if they aren't already
-    dense_shape = in_sparse.dense_shape
-    indices = in_sparse.indices
-    values = in_sparse.values
-
-    # Compute output dense shape after slicing
-    out_shape = tf.concat([[end], dense_shape[1:]], axis=0)
-
-    # Filter rows: select entries where indices[:, 0] < end
-    mask = indices[:, 0] < end
-    selected_indices = tf.boolean_mask(indices, mask)
-    selected_values = tf.boolean_mask(values, mask)
-
-    # Return the sliced sparse tensor
-    return tf.sparse.SparseTensor(
-        indices=selected_indices, values=selected_values, dense_shape=out_shape
-    )

--- a/combinetf2/h5pyutils.py
+++ b/combinetf2/h5pyutils.py
@@ -82,3 +82,27 @@ def writeSparse(indices, values, dense_shape, h5group, outname, maxChunkBytes=10
     outgroup.attrs["dense_shape"] = np.array(dense_shape, dtype="int64")
 
     return nbytes
+
+
+def simple_sparse_slice0end(in_sparse, end):
+    """
+    Slice a tf.sparse.SparseTensor along axis 0 starting 0 to the 'end'.
+    """
+
+    # Convert dense_shape, indices, and values to tensors if they aren't already
+    dense_shape = in_sparse.dense_shape
+    indices = in_sparse.indices
+    values = in_sparse.values
+
+    # Compute output dense shape after slicing
+    out_shape = tf.concat([[end], dense_shape[1:]], axis=0)
+
+    # Filter rows: select entries where indices[:, 0] < end
+    mask = indices[:, 0] < end
+    selected_indices = tf.boolean_mask(indices, mask)
+    selected_values = tf.boolean_mask(values, mask)
+
+    # Return the sliced sparse tensor
+    return tf.sparse.SparseTensor(
+        indices=selected_indices, values=selected_values, dense_shape=out_shape
+    )

--- a/combinetf2/inputdata.py
+++ b/combinetf2/inputdata.py
@@ -90,7 +90,6 @@ class FitInputData:
 
                 self.metadata = pickle_load_h5py(f["meta"])
                 self.channel_info = self.metadata["channel_info"]
-
             else:
                 self.channel_info = {
                     "ch0": {
@@ -103,8 +102,10 @@ class FitInputData:
                                 name="obs",
                             )
                         ]
-                    },
-                    "ch1": {
+                    }
+                }
+                if self.nbinsmasked:
+                    self.channel_info["ch1_masked"] = {
                         "axes": [
                             hist.axis.Integer(
                                 0,
@@ -114,8 +115,7 @@ class FitInputData:
                                 name="masked",
                             )
                         ]
-                    },
-                }
+                    }
 
             self.symmetric_tensor = self.metadata.get("symmetric_tensor", False)
             self.exponential_transform = self.metadata.get(
@@ -130,7 +130,7 @@ class FitInputData:
             for channel, info in self.channel_info.items():
                 axes = info["axes"]
                 shape = tuple([len(a) for a in axes])
-                size = np.prod(shape)
+                size = int(np.prod(shape))
 
                 start = ibin
                 stop = start + size

--- a/combinetf2/inputdata.py
+++ b/combinetf2/inputdata.py
@@ -64,8 +64,8 @@ class FitInputData:
                 print(
                     "WARNING: The sparse tensor implementation is experimental and probably slower than with a dense tensor!"
                 )
-                self.norm_sparse = makesparsetensor(f["hnorm_sparse"])
-                self.logk_sparse = makesparsetensor(f["hlogk_sparse"])
+                self.norm = makesparsetensor(f["hnorm_sparse"])
+                self.logk = makesparsetensor(f["hlogk_sparse"])
             else:
                 self.norm = maketensor(f["hnorm"])
                 self.logk = maketensor(f["hlogk"])

--- a/combinetf2/inputdata.py
+++ b/combinetf2/inputdata.py
@@ -27,8 +27,6 @@ class FitInputData:
                 self.pseudodatanames = []
 
             # load arrays from file
-            hconstraintweights = f["hconstraintweights"]
-            hdata_obs = f["hdata_obs"]
 
             if "hdata_cov_inv" in f.keys():
                 hdata_cov_inv = f["hdata_cov_inv"]
@@ -36,21 +34,47 @@ class FitInputData:
             else:
                 self.data_cov_inv = None
 
+            # load data/pseudodata
+            if pseudodata is not None:
+                if pseudodata in self.pseudodatanames:
+                    pseudodata_idx = np.where(self.pseudodatanames == pseudodata)[0][0]
+                else:
+                    raise Exception(
+                        "Pseudodata %s not found, available pseudodata sets are %s"
+                        % (pseudodata, self.pseudodatanames)
+                    )
+                print("Run pseudodata fit for index %i: " % (pseudodata_idx))
+                print(self.pseudodatanames[pseudodata_idx])
+                hdata_obs = f["hpseudodata"]
+
+                data_obs = maketensor(hdata_obs)
+                self.data_obs = data_obs[:, pseudodata_idx]
+            else:
+                self.data_obs = maketensor(f["hdata_obs"])
+
+            hkstat = f["hkstat"]
+            self.kstat = maketensor(hkstat)
+
+            # start by creating tensors which read in the hdf5 arrays (optimized for memory consumption)
+            self.constraintweights = maketensor(f["hconstraintweights"])
+
             self.sparse = not "hnorm" in f
 
             if self.sparse:
                 print(
                     "WARNING: The sparse tensor implementation is experimental and probably slower than with a dense tensor!"
                 )
-                hnorm_sparse = f["hnorm_sparse"]
-                hlogk_sparse = f["hlogk_sparse"]
+                self.norm_sparse = makesparsetensor(f["hnorm_sparse"])
+                self.logk_sparse = makesparsetensor(f["hlogk_sparse"])
             else:
-                hnorm = f["hnorm"]
-                hlogk = f["hlogk"]
+                self.norm = maketensor(f["hnorm"])
+                self.logk = maketensor(f["hlogk"])
 
             # infer some metadata from loaded information
-            self.dtype = hdata_obs.dtype
-            self.nbins = hdata_obs.shape[-1]
+            self.dtype = self.data_obs.dtype
+            self.nbins = self.data_obs.shape[-1]
+            self.nbinsfull = self.norm.shape[0]
+            self.nbinsmasked = self.nbinsfull - self.nbins
             self.nproc = len(self.procs)
             self.nsyst = len(self.systs)
             self.nsystnoprofile = len(self.systsnoprofile)
@@ -62,7 +86,6 @@ class FitInputData:
             # reference meta data if available
             self.metadata = {}
             if "meta" in f.keys():
-                # from narf.ioutils import pickle_load_h5py
                 from wums.ioutils import pickle_load_h5py
 
                 self.metadata = pickle_load_h5py(f["meta"])
@@ -80,7 +103,18 @@ class FitInputData:
                                 name="obs",
                             )
                         ]
-                    }
+                    },
+                    "ch1": {
+                        "axes": [
+                            hist.axis.Integer(
+                                0,
+                                self.nbinsmasked,
+                                underflow=False,
+                                overflow=False,
+                                name="masked",
+                            )
+                        ]
+                    },
                 }
 
             self.symmetric_tensor = self.metadata.get("symmetric_tensor", False)
@@ -110,39 +144,6 @@ class FitInputData:
                 print(channel, info)
 
             self.axis_procs = hist.axis.StrCategory(self.procs, name="processes")
-
-            # build tensorflow graph for likelihood calculation
-
-            # start by creating tensors which read in the hdf5 arrays (optimized for memory consumption)
-            self.constraintweights = maketensor(hconstraintweights)
-
-            # load data/pseudodata
-            if pseudodata is not None:
-                if pseudodata in self.pseudodatanames:
-                    pseudodata_idx = np.where(self.pseudodatanames == pseudodata)[0][0]
-                else:
-                    raise Exception(
-                        "Pseudodata %s not found, available pseudodata sets are %s"
-                        % (pseudodata, self.pseudodatanames)
-                    )
-                print("Run pseudodata fit for index %i: " % (pseudodata_idx))
-                print(self.pseudodatanames[pseudodata_idx])
-                hdata_obs = f["hpseudodata"]
-
-                data_obs = maketensor(hdata_obs)
-                self.data_obs = data_obs[:, pseudodata_idx]
-            else:
-                self.data_obs = maketensor(hdata_obs)
-
-            hkstat = f["hkstat"]
-            self.kstat = maketensor(hkstat)
-
-            if self.sparse:
-                self.norm_sparse = makesparsetensor(hnorm_sparse)
-                self.logk_sparse = makesparsetensor(hlogk_sparse)
-            else:
-                self.norm = maketensor(hnorm)
-                self.logk = maketensor(hlogk)
 
             self.normalize = normalize
             if self.normalize:

--- a/combinetf2/tensorwriter.py
+++ b/combinetf2/tensorwriter.py
@@ -116,26 +116,21 @@ class TensorWriter:
             self.dict_logkhalfdiff_indices[channel][name] = {}
 
         norm = self.get_flat_values(h)
+        sumw2 = self.get_flat_variances(h)
 
         if not self.allow_negative_expectation:
             norm = np.maximum(norm, 0.0)
-
+        if not np.all(np.isfinite(sumw2)):
+            raise RuntimeError(
+                f"{len(sumw2)-sum(np.isfinite(sumw2))} NaN or Inf values encountered in variances for {name}!"
+            )
         if not np.all(np.isfinite(norm)):
             raise RuntimeError(
                 f"{len(norm)-sum(np.isfinite(norm))} NaN or Inf values encountered in nominal histogram for {name}!"
             )
 
         self.dict_norm[channel][name] = norm
-
-        if not masked:
-            sumw2 = self.get_flat_variances(h)
-
-            if not np.all(np.isfinite(sumw2)):
-                raise RuntimeError(
-                    f"{len(sumw2)-sum(np.isfinite(sumw2))} NaN or Inf values encountered in variances for {name}!"
-                )
-
-            self.dict_sumw2[channel] += sumw2
+        self.dict_sumw2[channel] += sumw2
 
     def add_channel(self, axes, name=None, masked=False):
         if name is None:
@@ -144,13 +139,13 @@ class TensorWriter:
         ibins = np.prod([len(a) for a in axes])
         self.nbinschan[name] = ibins
         self.dict_norm[name] = {}
+        self.dict_sumw2[name] = np.zeros(ibins)
 
         # add masked channels last and not masked channels first
         this_channel = {"axes": axes, "masked": masked}
         if masked:
             self.channels[name] = this_channel
         else:
-            self.dict_sumw2[name] = np.zeros(ibins)
             self.channels = {name: this_channel, **self.channels}
 
         self.dict_logkavg[name] = {}
@@ -381,25 +376,19 @@ class TensorWriter:
         nbins = sum(
             [v for c, v in self.nbinschan.items() if not self.channels[c]["masked"]]
         )
+        # nbinsfull including masked channels
+        nbinsfull = sum([v for v in self.nbinschan.values()])
 
         print(f"Write out nominal arrays")
-        sumw = np.zeros([nbins], self.dtype)
-        sumw2 = np.zeros([nbins], self.dtype)
+        sumw = np.zeros([nbinsfull], self.dtype)
+        sumw2 = np.zeros([nbinsfull], self.dtype)
         data_obs = np.zeros([nbins], self.dtype)
         pseudodata = np.zeros([nbins, len(self.pseudodata_names)], self.dtype)
         ibin = 0
         for chan, chan_info in self.channels.items():
-            if chan_info["masked"]:
-                continue
             nbinschan = self.nbinschan[chan]
 
-            data_obs[ibin : ibin + nbinschan] = self.dict_data_obs[chan]
             sumw2[ibin : ibin + nbinschan] = self.dict_sumw2[chan]
-
-            for idx, name in enumerate(self.pseudodata_names):
-                pseudodata[ibin : ibin + nbinschan, idx] = self.dict_pseudodata[chan][
-                    name
-                ]
 
             for iproc, proc in enumerate(procs):
                 if proc not in self.dict_norm[chan]:
@@ -407,16 +396,15 @@ class TensorWriter:
 
                 sumw[ibin : ibin + nbinschan] += self.dict_norm[chan][proc]
 
+            if not chan_info["masked"]:
+                data_obs[ibin : ibin + nbinschan] = self.dict_data_obs[chan]
+
+                for idx, name in enumerate(self.pseudodata_names):
+                    pseudodata[ibin : ibin + nbinschan, idx] = self.dict_pseudodata[
+                        chan
+                    ][name]
+
             ibin += nbinschan
-
-        # compute poisson parameter for Barlow-Beeston bin-by-bin statistical uncertainties
-        kstat = np.square(sumw) / sumw2
-        # numerical protection to avoid poorly defined constraint
-        kstat = np.where(np.equal(sumw, 0.0), 1.0, kstat)
-        kstat = np.where(np.equal(sumw2, 0.0), 1.0, kstat)
-
-        # nbins including masked channels
-        nbins = sum([v for v in self.nbinschan.values()])
 
         systs = self.get_systs()
         nsyst = len(systs)
@@ -562,7 +550,7 @@ class TensorWriter:
             logk_sparse_values.resize([logk_sparse_size])
 
             # straightforward sorting of norm_sparse into canonical order
-            norm_sparse_dense_shape = (nbins, nproc)
+            norm_sparse_dense_shape = (nbinsfull, nproc)
             norm_sort_indices = np.argsort(
                 np.ravel_multi_index(
                     np.transpose(norm_sparse_indices), norm_sparse_dense_shape
@@ -600,11 +588,11 @@ class TensorWriter:
         else:
             print(f"Write out dense array")
             # initialize with zeros, i.e. no variation
-            norm = np.zeros([nbins, nproc], self.dtype)
+            norm = np.zeros([nbinsfull, nproc], self.dtype)
             if self.symmetric_tensor:
-                logk = np.zeros([nbins, nproc, nsyst], self.dtype)
+                logk = np.zeros([nbinsfull, nproc, nsyst], self.dtype)
             else:
-                logk = np.zeros([nbins, nproc, 2, nsyst], self.dtype)
+                logk = np.zeros([nbinsfull, nproc, 2, nsyst], self.dtype)
 
             for chan in self.channels.keys():
                 nbinschan = self.nbinschan[chan]
@@ -640,6 +628,12 @@ class TensorWriter:
                                 )
 
                 ibin += nbinschan
+
+        # compute poisson parameter for Barlow-Beeston bin-by-bin statistical uncertainties
+        kstat = np.square(sumw) / sumw2
+        # numerical protection to avoid poorly defined constraint
+        kstat = np.where(np.equal(sumw, 0.0), 1.0, kstat)
+        kstat = np.where(np.equal(sumw2, 0.0), 1.0, kstat)
 
         # write results to hdf5 file
         procSize = nproc * np.dtype(self.dtype).itemsize

--- a/combinetf2/tensorwriter.py
+++ b/combinetf2/tensorwriter.py
@@ -96,8 +96,8 @@ class TensorWriter:
             )
         self.dict_pseudodata[channel][name] = self.get_flat_values(h)
 
-    def add_process(self, h, name, channel="ch0", signal=False, masked=False):
-        self._check_hist_and_channel(h, channel, masked=masked)
+    def add_process(self, h, name, channel="ch0", signal=False):
+        self._check_hist_and_channel(h, channel)
 
         if name in self.dict_norm[channel].keys():
             raise RuntimeError(
@@ -142,7 +142,7 @@ class TensorWriter:
         self.dict_sumw2[name] = np.zeros(ibins)
 
         # add masked channels last and not masked channels first
-        this_channel = {"axes": axes, "masked": masked}
+        this_channel = {"axes": [a for a in axes], "masked": masked}
         if masked:
             self.channels[name] = this_channel
         else:
@@ -154,13 +154,10 @@ class TensorWriter:
             self.dict_logkavg_indices[name] = {}
             self.dict_logkhalfdiff_indices[name] = {}
 
-    def _check_hist_and_channel(self, h, channel, add=True, masked=False):
+    def _check_hist_and_channel(self, h, channel):
         axes = [a for a in h.axes]
         if channel not in self.channels.keys():
-            if add:
-                self.add_channel(axes, channel, masked=masked)
-            else:
-                raise RuntimeError(f"Channel {channel} not known!")
+            raise RuntimeError(f"Channel {channel} not known!")
         elif axes != self.channels[channel]["axes"]:
             raise RuntimeError(
                 f"""
@@ -218,8 +215,8 @@ class TensorWriter:
         var_name_out = name
 
         if isinstance(h, (list, tuple, np.ndarray)):
-            self._check_hist_and_channel(h[0], channel, add=False)
-            self._check_hist_and_channel(h[1], channel, add=False)
+            self._check_hist_and_channel(h[0], channel)
+            self._check_hist_and_channel(h[1], channel)
 
             syst_up = self.get_flat_values(h[0])
             syst_down = self.get_flat_values(h[1])
@@ -267,7 +264,7 @@ class TensorWriter:
             logkup_proc = None
             logkdown_proc = None
         elif mirror:
-            self._check_hist_and_channel(h, channel, add=False)
+            self._check_hist_and_channel(h, channel)
             syst = self.get_flat_values(h)
             logkavg_proc = self.get_logk(syst, norm, kfactor)
         else:

--- a/combinetf2/tfhelpers.py
+++ b/combinetf2/tfhelpers.py
@@ -1,0 +1,25 @@
+import tensorflow as tf
+
+
+def simple_sparse_slice0end(in_sparse, end):
+    """
+    Slice a tf.sparse.SparseTensor along axis 0 starting 0 to the 'end'.
+    """
+
+    # Convert dense_shape, indices, and values to tensors if they aren't already
+    dense_shape = in_sparse.dense_shape
+    indices = in_sparse.indices
+    values = in_sparse.values
+
+    # Compute output dense shape after slicing
+    out_shape = tf.concat([[end], dense_shape[1:]], axis=0)
+
+    # Filter rows: select entries where indices[:, 0] < end
+    mask = indices[:, 0] < end
+    selected_indices = tf.boolean_mask(indices, mask)
+    selected_values = tf.boolean_mask(values, mask)
+
+    # Return the sliced sparse tensor
+    return tf.sparse.SparseTensor(
+        indices=selected_indices, values=selected_values, dense_shape=out_shape
+    )

--- a/combinetf2/workspace.py
+++ b/combinetf2/workspace.py
@@ -166,6 +166,8 @@ class Workspace:
         hists_nobs = {}
 
         for channel, info in channel_info.items():
+            if info["masked"]:
+                continue
             axes = info["axes"]
 
             start = info["start"]

--- a/tests/make_tensor.py
+++ b/tests/make_tensor.py
@@ -177,6 +177,9 @@ writer = tensorwriter.TensorWriter(
     exponential_transform=args.exponentialTransform,
 )
 
+writer.add_channel(h1_data.axes, "ch0")
+writer.add_channel(h2_data.axes, "ch1")
+
 writer.add_data(h1_data, "ch0")
 writer.add_data(h2_data, "ch1")
 
@@ -195,7 +198,8 @@ writer.add_process(h1_bkg_2, "bkg_2", "ch0")
 
 if not args.skipMaskedChannels:
     # add masked channel
-    writer.add_process(h1_sig_masked, "sig", "ch0_masked", signal=True, masked=True)
+    writer.add_channel(h1_sig_masked.axes, "ch0_masked", masked=True)
+    writer.add_process(h1_sig_masked, "sig", "ch0_masked", signal=True)
 
 # systematic uncertainties
 


### PR DESCRIPTION
- Add masked channels similar as it was done in combinetf1. 
- Masked channels are always added trailing while not masked channels are added leading
- To avoid calculating the yields in the masked channel during likelihood minimization the masked channels can be clipped in ```_compute_yields```
- Bin by bin uncertainties in the masked channel are treated in the same way with the exception that they are never profiled and don't contribute to the likelihood. 
- Previously the fitter had an attribute 'profile' as global variable to steer if the systematics are profiled or not. However, this is captured in the tf graph and would not be able to change one the graph is traced. But since his is expected to change between prefit and postfit, it was changed to use function parameter instead.