### PR TITLE
Remove python conditionals from tf.function that are known at init

### DIFF
--- a/bin/combinetf2_fit.py
+++ b/bin/combinetf2_fit.py
@@ -27,6 +27,12 @@ def make_parser():
     parser.add_argument(
         "--noColorLogger", action="store_true", help="Do not use logging with colors"
     )
+    parser.add_argument(
+        "--eager",
+        action="store_true",
+        default=False,
+        help="Run tensorflow in eager mode (for debugging)",
+    )
     parser.add_argument("filename", help="filename of the main hdf5 input")
     parser.add_argument("-o", "--output", default="./", help="output directory")
     parser.add_argument("--outname", default="fitresults.hdf5", help="output file name")
@@ -516,6 +522,9 @@ def fit(args, fitter, ws, dofit=True):
 def main():
     start_time = time.time()
     args = make_parser()
+
+    if args.eager:
+        tf.config.run_functions_eagerly(True)
 
     global logger
     logger = logging.setup_logger(__file__, args.verbose, args.noColorLogger)

--- a/bin/combinetf2_fit.py
+++ b/bin/combinetf2_fit.py
@@ -17,7 +17,7 @@ def make_parser():
 
     parser.add_argument("filename", help="filename of the main hdf5 input")
     parser.add_argument("-o", "--output", default="./", help="output directory")
-    parser.add_argument("--outname", default="fitresults", help="output file name")
+    parser.add_argument("--outname", default="fitresults.hdf5", help="output file name")
     parser.add_argument(
         "--postfix",
         default=None,
@@ -232,6 +232,7 @@ def save_hists(args, fitter, ws, prefit=True):
     exp, aux = fitter.expected_events(
         inclusive=True,
         compute_variance=args.computeHistErrors,
+        compute_cov=args.computeHistCov,
         compute_chi2=not args.noChi2,
         compute_global_impacts=args.computeHistImpacts and not prefit,
     )
@@ -274,6 +275,7 @@ def save_hists(args, fitter, ws, prefit=True):
             axes=axes,
             inclusive=True,
             compute_variance=args.computeHistErrors,
+            compute_cov=args.computeHistCov,
             compute_chi2=not args.noChi2,
             compute_global_impacts=args.computeHistImpacts and not prefit,
         )

--- a/bin/combinetf2_fit.py
+++ b/bin/combinetf2_fit.py
@@ -267,24 +267,26 @@ def save_hists(args, fitter, ws, prefit=True):
 
     for p in args.project:
         channel = p[0]
-        axes = p[1:]
+        axes_names = p[1:]
+        channel_info = fitter.indata.channel_info[channel]
+        channel_axes = channel_info["axes"]
+
         print(f"Save projection for channel {channel} - inclusive")
 
         exp, aux = fitter.expected_events_projection(
             channel=channel,
-            axes=axes,
+            axes=axes_names,
             inclusive=True,
             compute_variance=args.computeHistErrors,
             compute_cov=args.computeHistCov,
             compute_chi2=not args.noChi2,
             compute_global_impacts=args.computeHistImpacts and not prefit,
+            masked=channel_info["masked"],
         )
-
-        channel_axes = fitter.indata.channel_info[channel]["axes"]
 
         ws.add_expected_projection_hists(
             channel,
-            axes,
+            axes_names,
             channel_axes,
             exp,
             var=aux[0],
@@ -301,14 +303,15 @@ def save_hists(args, fitter, ws, prefit=True):
 
             exp, aux = fitter.expected_events_projection(
                 channel=channel,
-                axes=axes,
+                axes=axes_names,
                 inclusive=False,
                 compute_variance=args.computeHistErrors,
+                masked=channel_info["masked"],
             )
 
             ws.add_expected_projection_hists(
                 channel,
-                axes,
+                axes_names,
                 channel_axes,
                 exp,
                 var=aux[0],

--- a/bin/combinetf2_plot_hists_cov.py
+++ b/bin/combinetf2_plot_hists_cov.py
@@ -71,7 +71,7 @@ def parseArgs():
     )
     parser.add_argument(
         "--subtitle",
-        default=None,
+        default="",
         type=str,
         help="Subtitle to be printed after title",
     )

--- a/bin/combinetf2_plot_hists_uncertainties.py
+++ b/bin/combinetf2_plot_hists_uncertainties.py
@@ -94,7 +94,7 @@ def parseArgs():
     )
     parser.add_argument(
         "--subtitle",
-        default=None,
+        default="",
         type=str,
         help="Subtitle to be printed after title",
     )

--- a/bin/combinetf2_plot_inputdata.py
+++ b/bin/combinetf2_plot_inputdata.py
@@ -586,7 +586,11 @@ def main():
             hists_syst_up = []
 
         # setup data histogram
-        if args.noData or args.splitByProcess:
+        if (
+            args.noData
+            or args.splitByProcess
+            or channel not in debug.data_obs_hists.keys()
+        ):
             hist_data = None
         else:
             hist_data_tmp = debug.data_obs_hists[channel]

--- a/bin/combinetf2_plot_likelihood_scan.py
+++ b/bin/combinetf2_plot_likelihood_scan.py
@@ -78,7 +78,7 @@ def parseArgs():
     )
     parser.add_argument(
         "--subtitle",
-        default=None,
+        default="",
         type=str,
         help="Subtitle to be printed after title",
     )

--- a/bin/combinetf2_plot_likelihood_scan2D.py
+++ b/bin/combinetf2_plot_likelihood_scan2D.py
@@ -79,7 +79,7 @@ def parseArgs():
     )
     parser.add_argument(
         "--subtitle",
-        default=None,
+        default="",
         type=str,
         help="Subtitle to be printed after title",
     )

--- a/bin/combinetf2_plot_pulls_and_impacts.py
+++ b/bin/combinetf2_plot_pulls_and_impacts.py
@@ -651,7 +651,7 @@ def parseArgs():
     )
     parser.add_argument(
         "--subtitle",
-        default=None,
+        default="",
         type=str,
         help="Subtitle to be printed after title",
     )

--- a/bin/combinetf2_print_impacts.py
+++ b/bin/combinetf2_print_impacts.py
@@ -59,10 +59,11 @@ def printImpacts(args, fitresult, poi):
         labels = labels[order]
         impacts = impacts[order]
 
+    nround = 5
     if args.asymImpacts:
-        fimpact = lambda x: f"{round(max(x)*100, 2)} / {round(min(x)*100, 2)}"
+        fimpact = lambda x: f"{round(max(x)*100, nround)} / {round(min(x)*100, nround)}"
     else:
-        fimpact = lambda x: round(x * 100, 2)
+        fimpact = lambda x: round(x * 100, nround)
 
     if args.nuisance:
         if args.nuisance not in labels:

--- a/combinetf2/debugdata.py
+++ b/combinetf2/debugdata.py
@@ -32,10 +32,11 @@ class FitDebugData:
             else:
                 shape_logk = [*shape, self.indata.nproc, 2, self.indata.nsyst]
 
-            data_obs_hist = hist.Hist(*axes, name=f"{channel}_data_obs")
-            data_obs_hist.values()[...] = memoryview(
-                tf.reshape(self.indata.data_obs[ibin:stop], shape)
-            )
+            if not info["masked"]:
+                data_obs_hist = hist.Hist(*axes, name=f"{channel}_data_obs")
+                data_obs_hist.values()[...] = memoryview(
+                    tf.reshape(self.indata.data_obs[ibin:stop], shape)
+                )
 
             nominal_hist = hist.Hist(*axes, self.axis_procs, name=f"{channel}_nominal")
             nominal_hist.values()[...] = memoryview(
@@ -85,7 +86,8 @@ class FitDebugData:
                 nonzero, axis=tuple(range(len(axes)))
             )
 
-            self.data_obs_hists[channel] = data_obs_hist
+            if not info["masked"]:
+                self.data_obs_hists[channel] = data_obs_hist
             self.nominal_hists[channel] = nominal_hist
             self.syst_hists[channel] = syst_hist
             self.syst_active_hists[channel] = syst_active_hist

--- a/combinetf2/fitter.py
+++ b/combinetf2/fitter.py
@@ -747,7 +747,7 @@ class Fitter:
             exp, expvar, expcov, exp_impacts, exp_impacts_grouped = (
                 self.expected_with_variance(
                     fun,
-                    compute_cov=compute_variance,
+                    compute_cov=compute_cov,
                     compute_global_impacts=compute_global_impacts,
                 )
             )

--- a/combinetf2/h5pyutils.py
+++ b/combinetf2/h5pyutils.py
@@ -82,3 +82,27 @@ def writeSparse(indices, values, dense_shape, h5group, outname, maxChunkBytes=10
     outgroup.attrs["dense_shape"] = np.array(dense_shape, dtype="int64")
 
     return nbytes
+
+
+def simple_sparse_slice0end(in_sparse, end):
+    """
+    Slice a tf.sparse.SparseTensor along axis 0 starting 0 to the 'end'.
+    """
+
+    # Convert dense_shape, indices, and values to tensors if they aren't already
+    dense_shape = in_sparse.dense_shape
+    indices = in_sparse.indices
+    values = in_sparse.values
+
+    # Compute output dense shape after slicing
+    out_shape = tf.concat([[end], dense_shape[1:]], axis=0)
+
+    # Filter rows: select entries where indices[:, 0] < end
+    mask = indices[:, 0] < end
+    selected_indices = tf.boolean_mask(indices, mask)
+    selected_values = tf.boolean_mask(values, mask)
+
+    # Return the sliced sparse tensor
+    return tf.sparse.SparseTensor(
+        indices=selected_indices, values=selected_values, dense_shape=out_shape
+    )

--- a/combinetf2/inputdata.py
+++ b/combinetf2/inputdata.py
@@ -64,8 +64,8 @@ class FitInputData:
                 print(
                     "WARNING: The sparse tensor implementation is experimental and probably slower than with a dense tensor!"
                 )
-                self.norm_sparse = makesparsetensor(f["hnorm_sparse"])
-                self.logk_sparse = makesparsetensor(f["hlogk_sparse"])
+                self.norm = makesparsetensor(f["hnorm_sparse"])
+                self.logk = makesparsetensor(f["hlogk_sparse"])
             else:
                 self.norm = maketensor(f["hnorm"])
                 self.logk = maketensor(f["hlogk"])

--- a/combinetf2/inputdata.py
+++ b/combinetf2/inputdata.py
@@ -27,8 +27,6 @@ class FitInputData:
                 self.pseudodatanames = []
 
             # load arrays from file
-            hconstraintweights = f["hconstraintweights"]
-            hdata_obs = f["hdata_obs"]
 
             if "hdata_cov_inv" in f.keys():
                 hdata_cov_inv = f["hdata_cov_inv"]
@@ -36,21 +34,47 @@ class FitInputData:
             else:
                 self.data_cov_inv = None
 
+            # load data/pseudodata
+            if pseudodata is not None:
+                if pseudodata in self.pseudodatanames:
+                    pseudodata_idx = np.where(self.pseudodatanames == pseudodata)[0][0]
+                else:
+                    raise Exception(
+                        "Pseudodata %s not found, available pseudodata sets are %s"
+                        % (pseudodata, self.pseudodatanames)
+                    )
+                print("Run pseudodata fit for index %i: " % (pseudodata_idx))
+                print(self.pseudodatanames[pseudodata_idx])
+                hdata_obs = f["hpseudodata"]
+
+                data_obs = maketensor(hdata_obs)
+                self.data_obs = data_obs[:, pseudodata_idx]
+            else:
+                self.data_obs = maketensor(f["hdata_obs"])
+
+            hkstat = f["hkstat"]
+            self.kstat = maketensor(hkstat)
+
+            # start by creating tensors which read in the hdf5 arrays (optimized for memory consumption)
+            self.constraintweights = maketensor(f["hconstraintweights"])
+
             self.sparse = not "hnorm" in f
 
             if self.sparse:
                 print(
                     "WARNING: The sparse tensor implementation is experimental and probably slower than with a dense tensor!"
                 )
-                hnorm_sparse = f["hnorm_sparse"]
-                hlogk_sparse = f["hlogk_sparse"]
+                self.norm_sparse = makesparsetensor(f["hnorm_sparse"])
+                self.logk_sparse = makesparsetensor(f["hlogk_sparse"])
             else:
-                hnorm = f["hnorm"]
-                hlogk = f["hlogk"]
+                self.norm = maketensor(f["hnorm"])
+                self.logk = maketensor(f["hlogk"])
 
             # infer some metadata from loaded information
-            self.dtype = hdata_obs.dtype
-            self.nbins = hdata_obs.shape[-1]
+            self.dtype = self.data_obs.dtype
+            self.nbins = self.data_obs.shape[-1]
+            self.nbinsfull = self.norm.shape[0]
+            self.nbinsmasked = self.nbinsfull - self.nbins
             self.nproc = len(self.procs)
             self.nsyst = len(self.systs)
             self.nsystnoprofile = len(self.systsnoprofile)
@@ -62,7 +86,6 @@ class FitInputData:
             # reference meta data if available
             self.metadata = {}
             if "meta" in f.keys():
-                # from narf.ioutils import pickle_load_h5py
                 from wums.ioutils import pickle_load_h5py
 
                 self.metadata = pickle_load_h5py(f["meta"])
@@ -80,7 +103,18 @@ class FitInputData:
                                 name="obs",
                             )
                         ]
-                    }
+                    },
+                    "ch1": {
+                        "axes": [
+                            hist.axis.Integer(
+                                0,
+                                self.nbinsmasked,
+                                underflow=False,
+                                overflow=False,
+                                name="masked",
+                            )
+                        ]
+                    },
                 }
 
             self.symmetric_tensor = self.metadata.get("symmetric_tensor", False)
@@ -110,39 +144,6 @@ class FitInputData:
                 print(channel, info)
 
             self.axis_procs = hist.axis.StrCategory(self.procs, name="processes")
-
-            # build tensorflow graph for likelihood calculation
-
-            # start by creating tensors which read in the hdf5 arrays (optimized for memory consumption)
-            self.constraintweights = maketensor(hconstraintweights)
-
-            # load data/pseudodata
-            if pseudodata is not None:
-                if pseudodata in self.pseudodatanames:
-                    pseudodata_idx = np.where(self.pseudodatanames == pseudodata)[0][0]
-                else:
-                    raise Exception(
-                        "Pseudodata %s not found, available pseudodata sets are %s"
-                        % (pseudodata, self.pseudodatanames)
-                    )
-                print("Run pseudodata fit for index %i: " % (pseudodata_idx))
-                print(self.pseudodatanames[pseudodata_idx])
-                hdata_obs = f["hpseudodata"]
-
-                data_obs = maketensor(hdata_obs)
-                self.data_obs = data_obs[:, pseudodata_idx]
-            else:
-                self.data_obs = maketensor(hdata_obs)
-
-            hkstat = f["hkstat"]
-            self.kstat = maketensor(hkstat)
-
-            if self.sparse:
-                self.norm_sparse = makesparsetensor(hnorm_sparse)
-                self.logk_sparse = makesparsetensor(hlogk_sparse)
-            else:
-                self.norm = maketensor(hnorm)
-                self.logk = maketensor(hlogk)
 
             self.normalize = normalize
             if self.normalize:

--- a/combinetf2/workspace.py
+++ b/combinetf2/workspace.py
@@ -166,6 +166,8 @@ class Workspace:
         hists_nobs = {}
 
         for channel, info in channel_info.items():
+            if info["masked"]:
+                continue
             axes = info["axes"]
 
             start = info["start"]

--- a/combinetf2/workspace.py
+++ b/combinetf2/workspace.py
@@ -109,7 +109,7 @@ class Workspace:
             if not os.path.exists(outfolder):
                 os.makedirs(outfolder)
 
-        if "." not in file_path and file_path.split(".")[-1]:
+        if "." not in outname:
             file_path += f".{self.extension}"
 
         if postfix is not None:


### PR DESCRIPTION
A separate branch in the tf graph is build for each python conditional. But many python conditionals are known at init and the branches will never be evaluated. To minimize the graph building time and graph size, these conditionals are moved to 'Fitter.__init__' to define relevant function blocks there. The time saved is minimal at the moment but it allows to support more options in the future w/o degrading the performance. This also cleans up the code.