### PR TITLE
Additional fit options and fixes/improvements to impacts and toys

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ source setup.sh
 
 An example can be found in ```tests/make_tensor.py -o test_tensor.hdf5```. 
 
+### Systematic uncertainties
+Systematic uncertainties are implemented by default using a log-normal probability density (with a multiplicative effect on the event yield).  Gaussian uncertainties with an additive effect on the event yield can also be used.  This is configured through the `systematic_type` parameter of the `TensorWriter`.
+
 ### Sparse tensor
 By setting `sparse=True` in the `TensorWriter` constructor the tensor is stored in the sparse representation. 
 This is useful when working with a sparse tensor, e.g. having many bins/processes/systematics where each bin/process/systematic only contributes to a small number of bins/processes/systematics. 
@@ -97,6 +100,9 @@ For example:
 ```bash
 combinetf2_fit test_tensor.hdf5 -o results/fitresult.hdf5 -t 0 --doImpacts --globalImpacts --binByBinStat --saveHists --computeHistErrors --project ch1 a --project ch1 b
 ```
+
+### Bin-by-bin statistical uncertainties
+Bin-by-bin statistical uncertainties on the templates can be added at runtime using the `--binByBinStat` option.  The Barlow-Beeston lite method is used to add implicit nuisance parameters for each template bin.  By default this is implemented using a gamma distribution for the probability density, but Gaussian uncertainties can also be used with `--binByBinStatType normal`.
 
 ## Fit diagnostics
 

--- a/bin/combinetf2_fit.py
+++ b/bin/combinetf2_fit.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import tensorflow as tf
+
 tf.config.experimental.enable_op_determinism()
 
 import argparse
@@ -8,7 +9,6 @@ import time
 
 import h5py
 import numpy as np
-
 
 from combinetf2 import fitter, inputdata, io_tools, workspace
 
@@ -190,7 +190,7 @@ def make_parser():
     parser.add_argument(
         "--binByBinStat_type",
         default="gamma",
-        choices = ["gamma", "normal"],
+        choices=["gamma", "normal"],
         help="probability density for bin-by-bin statistical uncertainties",
     )
     parser.add_argument(
@@ -363,7 +363,7 @@ def save_hists(args, fitter, ws, prefit=True, profile=False):
             inclusive=True,
             compute_variance=False,
             compute_variations=True,
-            profile=False
+            profile=False,
         )
 
         ws.add_expected_hists(
@@ -451,14 +451,20 @@ def fit(args, fitter, ws, dofit=True):
 
         # FIXME catch this exception to mark failed toys and continue
         if tf.reduce_any(tf.math.is_nan(chol)).numpy():
-            raise ValueError("Cholesky decomposition failed, Hessian is not positive-definite")
+            raise ValueError(
+                "Cholesky decomposition failed, Hessian is not positive-definite"
+            )
 
         gradv = grad[..., None]
-        edmval = 0.5 * tf.linalg.matmul(gradv, tf.linalg.cholesky_solve(chol, gradv), transpose_a=True)
-        edmval = edmval[0,0].numpy()
+        edmval = 0.5 * tf.linalg.matmul(
+            gradv, tf.linalg.cholesky_solve(chol, gradv), transpose_a=True
+        )
+        edmval = edmval[0, 0].numpy()
         logger.info(f"edmval: {edmval}")
 
-        fitter.cov.assign(tf.linalg.cholesky_solve(chol, tf.eye(chol.shape[0], dtype=chol.dtype)))
+        fitter.cov.assign(
+            tf.linalg.cholesky_solve(chol, tf.eye(chol.shape[0], dtype=chol.dtype))
+        )
 
         del chol
 

--- a/bin/combinetf2_fit.py
+++ b/bin/combinetf2_fit.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 
+import tensorflow as tf
+tf.config.experimental.enable_op_determinism()
+
 import argparse
 import time
 
 import h5py
 import numpy as np
-import tensorflow as tf
+
 
 from combinetf2 import fitter, inputdata, io_tools, workspace
 

--- a/bin/combinetf2_fit.py
+++ b/bin/combinetf2_fit.py
@@ -188,7 +188,7 @@ def make_parser():
         help="add bin-by-bin statistical uncertainties on templates (adding sumW2 on variance)",
     )
     parser.add_argument(
-        "--binByBinStat_type",
+        "--binByBinStatType",
         default="gamma",
         choices=["gamma", "normal"],
         help="probability density for bin-by-bin statistical uncertainties",

--- a/combinetf2/fitter.py
+++ b/combinetf2/fitter.py
@@ -1129,7 +1129,7 @@ class Fitter:
             lsaturated = tf.reduce_sum(-nobs * lognobs + nobs, axis=-1)
 
         if self.binByBinStat:
-            if self.binByBinStatType == "log_normal":
+            if self.binByBinStatType == "gamma":
                 kstat = self.indata.kstat[: self.indata.nbins]
                 beta0 = self.beta0[: self.indata.nbins]
                 lsaturated += tf.reduce_sum(

--- a/combinetf2/fitter.py
+++ b/combinetf2/fitter.py
@@ -112,21 +112,20 @@ class Fitter:
         # nuisance parameters for mc stat uncertainty
         self.beta = tf.Variable(self.beta0, trainable=False, name="beta")
 
-        if self.binByBinStat:
-            # cache the constraint variance since it's used in several places
-            # this is treated as a constant
-            if self.binByBinStat_type == "gamma":
-                self.varbeta = tf.stop_gradient(tf.math.reciprocal(self.indata.kstat))
-            elif self.binByBinStat_type == "normal":
-                n0 = self.expected_events_nominal()
-                self.varbeta = tf.stop_gradient(n0**2 / self.indata.kstat)
+        # cache the constraint variance since it's used in several places
+        # this is treated as a constant
+        if self.binByBinStat_type == "gamma":
+            self.varbeta = tf.stop_gradient(tf.math.reciprocal(self.indata.kstat))
+        elif self.binByBinStat_type == "normal":
+            n0 = self.expected_events_nominal()
+            self.varbeta = tf.stop_gradient(n0**2 / self.indata.kstat)
 
-                if self.externalCovariance:
-                    # precompute decomposition of composite matrix to speed up
-                    # calculation of profiled beta values
-                    self.betaauxlu = tf.linalg.lu(
-                        self.data_cov_inv + tf.diag(tf.reciprocal(self.varbeta))
-                    )
+            if self.binByBinStat and self.externalCovariance:
+                # precompute decomposition of composite matrix to speed up
+                # calculation of profiled beta values
+                self.betaauxlu = tf.linalg.lu(
+                    self.data_cov_inv + tf.diag(tf.reciprocal(self.varbeta))
+                )
 
         self.nexpnom = tf.Variable(
             self.expected_yield(), trainable=False, name="nexpnom"

--- a/combinetf2/fitter.py
+++ b/combinetf2/fitter.py
@@ -550,12 +550,12 @@ class Fitter:
         # FIXME switch back to optimized version at some point?
 
         with tf.GradientTape() as t:
-            t.watch([self.theta0, self.nobs, self.beta0])
+            t.watch([self.theta0, self.nobs, self.beta])
             expected = fun_exp()
             expected_flat = tf.reshape(expected, (-1,))
-        pdexpdx, pdexpdnobs, pdexpdbeta0 = t.jacobian(
+        pdexpdx, pdexpdnobs, pdexpdbeta = t.jacobian(
             expected_flat,
-            [self.x, self.nobs, self.beta0],
+            [self.x, self.nobs, self.beta],
         )
 
         expcov = pdexpdx @ tf.matmul(self.cov, pdexpdx, transpose_b=True)
@@ -567,8 +567,8 @@ class Fitter:
 
         expcov_noBBB = expcov
         if self.binByBinStat:
-            varbeta0 = self.varbeta
-            exp_cov_BBB = pdexpdbeta0 @ (varbeta0[:, None] * tf.transpose(pdexpdbeta0))
+            varbeta = self.varbeta
+            exp_cov_BBB = pdexpdbeta @ (varbeta[:, None] * tf.transpose(pdexpdbeta))
             expcov += exp_cov_BBB
 
         if compute_global_impacts:

--- a/combinetf2/fitter.py
+++ b/combinetf2/fitter.py
@@ -176,14 +176,16 @@ class Fitter:
             # TODO properly implement randomization of constraint parameters associated with bin-by-bin stat nuisances for frequentist toys,
             # currently bin-by-bin stat fluctuations are always handled in a bayesian way in toys
             # this also means bin-by-bin stat fluctuations are not consistently propagated for bootstrap toys from data
-            self.beta0.assign(
-                tf.random.gamma(
-                    shape=[],
-                    alpha=self.indata.kstat + 1.0,
-                    beta=self.indata.kstat,
-                    dtype=self.beta0.dtype,
-                )
-            )
+            raise NotImplementedError("binByBinStat not currently supported for toys")
+
+            # self.beta0.assign(
+            #     tf.random.gamma(
+            #         shape=[],
+            #         alpha=self.indata.kstat + 1.0,
+            #         beta=self.indata.kstat,
+            #         dtype=self.beta0.dtype,
+            #     )
+            # )
 
         if bootstrap_data:
             # randomize from observed data

--- a/combinetf2/fitter.py
+++ b/combinetf2/fitter.py
@@ -844,11 +844,6 @@ class Fitter:
         else:
             beta = None
 
-        if self.indata.exponential_transform:
-            nexp = self.indata.exponential_transform_scale * tf.math.log(nexp)
-            if compute_norm:
-                norm = self.indata.exponential_transform_scale * tf.math.log(norm)
-
         return nexp, norm, beta
 
     @tf.function
@@ -1028,8 +1023,6 @@ class Fitter:
             def proj_fun():
                 exp = fun_flat()[start:stop]
                 exp = tf.reshape(exp, exp_shape)
-                if self.indata.exponential_transform:
-                    exp = self.indata.exponential_transform_scale * tf.math.log(exp)
                 exp = tf.reduce_sum(exp, axis=proj_idxs)
                 exp = tf.transpose(exp, perm=transpose_idxs)
 

--- a/combinetf2/fitter.py
+++ b/combinetf2/fitter.py
@@ -104,15 +104,15 @@ class Fitter:
         )
 
         # FIXME for now this is needed even if binByBinStat is off because of how it is used in the global impacts
-        # computation (corresponding disconnected gradient is propagated as zero rather than skipping it entirely)
+        #  and uncertainty band computations (gradient is allowed to be zero or None and then propagated or skipped only later)
 
         # global observables for mc stat uncertainty
         self.beta0 = tf.Variable(self._default_beta0(), trainable=False, name="beta0")
 
-        if self.binByBinStat:
-            # nuisance parameters for mc stat uncertainty
-            self.beta = tf.Variable(self.beta0, trainable=False, name="beta")
+        # nuisance parameters for mc stat uncertainty
+        self.beta = tf.Variable(self.beta0, trainable=False, name="beta")
 
+        if self.binByBinStat:
             # cache the constraint variance since it's used in several places
             # this is treated as a constant
             if self.binByBinStat_type == "gamma":

--- a/combinetf2/fitter.py
+++ b/combinetf2/fitter.py
@@ -1,14 +1,17 @@
 import numpy as np
 import scipy
 import tensorflow as tf
+from wums import logging
 
 from combinetf2.tfhelpers import simple_sparse_slice0end
 
+logger = logging.child_logger(__name__)
 
 class Fitter:
     def __init__(self, indata, options):
         self.indata = indata
         self.binByBinStat = options.binByBinStat
+        self.binByBinStat_type = options.binByBinStat_type
         self.normalize = options.normalize
         self.systgroupsfull = self.indata.systgroups.tolist()
         self.systgroupsfull.append("stat")
@@ -19,10 +22,16 @@ class Fitter:
             raise Exception(
                 'option "--externalCovariance" only works with "--chisqFit"'
             )
-        if options.externalCovariance and options.binByBinStat:
+        if options.externalCovariance and options.binByBinStat and options.binByBinStat_type != "normal":
             raise Exception(
-                'option "--binByBinStat" currently not supported for options "--externalCovariance"'
+                'option "--binByBinStat" only for options "--externalCovariance" with "--binByBinStat_type normal"'
             )
+
+        if self.binByBinStat_type not in ["gamma", "normal"]:
+            raise RuntimeError(f"Invalid binByBinStat_type {self.indata.binByBinStat_type}, valid choices are 'gamma' or 'normal'")
+
+        if self.indata.systematic_type not in ["log_normal", "normal"]:
+            raise RuntimeError(f"Invalid systematic_type {self.indata.systematic_type}, valid choices are 'log_normal' or 'normal'")
 
         self.chisqFit = options.chisqFit
         self.externalCovariance = options.externalCovariance
@@ -77,7 +86,6 @@ class Fitter:
                     raise RuntimeError(
                         "Bins in 'nobs <= 0' encountered, chi^2 fit can not be performed."
                     )
-                self.data_cov_inv = tf.linalg.diag(tf.math.reciprocal(self.nobs))
 
         # constraint minima for nuisance parameters
         self.theta0 = tf.Variable(
@@ -86,17 +94,32 @@ class Fitter:
             name="theta0",
         )
 
+        # FIXME for now this is needed even if binByBinStat is off because of how it is used in the global impacts
+        # computation (corresponding disconnected gradient is propagated as zero rather than skipping it entirely)
+
         # global observables for mc stat uncertainty
-        if self.indata.systematic_type == "log_normal":
-            self.beta0 = tf.Variable(
-                tf.ones_like(self.indata.kstat), trainable=False, name="beta0"
+        self.beta0 = tf.Variable(
+            self._default_beta0(), trainable=False, name="beta0"
+        )
+
+        if self.binByBinStat:
+            # nuisance parameters for mc stat uncertainty
+            self.beta = tf.Variable(
+                self.beta0, trainable=False, name="beta"
             )
-        elif self.indata.systematic_type == "normal":
-            self.beta0 = tf.Variable(
-                tf.zeros_like(self.indata.kstat), trainable=False, name="beta0"
-            )
-        else:
-            raise RuntimeError(f"Invalid systematic_type {self.indata.systematic_type}, valid choices are 'log_normal' or 'normal'")
+
+            # cache the constraint variance since it's used in several places
+            # this is treated as a constant
+            if self.binByBinStat_type == "gamma":
+                self.varbeta = tf.stop_gradient(tf.math.reciprocal(self.indata.kstat))
+            elif self.binByBinStat_type == "normal":
+                n0 = self.expected_events_nominal()
+                self.varbeta = tf.stop_gradient(n0**2/self.indata.kstat)
+
+                if self.externalCovariance:
+                    # precompute decomposition of composite matrix to speed up
+                    # calculation of profiled beta values
+                    self.betaauxlu = tf.linalg.lu(self.data_cov_inv + tf.diag(tf.reciprocal(self.varbeta)))
 
         self.nexpnom = tf.Variable(
             self.expected_yield(), trainable=False, name="nexpnom"
@@ -106,7 +129,13 @@ class Fitter:
         self.cov = tf.Variable(self.prefit_covariance(), trainable=False, name="cov")
 
         # determine if problem is linear (ie likelihood is purely quadratic)
-        self.is_linear = self.chisqFit and self.indata.symmetric_tensor and self.indata.systematic_type == "normal" and self.npoi == 0
+        self.is_linear = self.chisqFit and self.indata.symmetric_tensor and self.indata.systematic_type == "normal" and self.npoi == 0 and ((not self.binByBinStat) or self.binByBinStat_type == "normal")
+
+    def _default_beta0(self):
+        if self.binByBinStat_type == "gamma":
+            return tf.ones_like(self.indata.kstat)
+        elif self.binByBinStat_type == "normal":
+            return tf.zeros_like(self.indata.kstat)
 
     def prefit_covariance(self, unconstrained_err=0.0):
         # free parameters are taken to have zero uncertainty for the purposes of prefit uncertainties
@@ -141,20 +170,21 @@ class Fitter:
             self.x.assign(tf.concat([self.xpoidefault, self.theta0], axis=0))
 
     def beta0defaultassign(self):
-        if self.indata.systematic_type == "log_normal":
-            self.beta0.assign(tf.ones_like(self.indata.kstat, dtype=self.beta0.dtype))
-        elif self.indata.systematic_type == "normal":
-            self.beta0.assign(tf.zeros_like(self.indata.kstat, dtype=self.beta0.dtype))
-        else:
-            raise RuntimeError(f"Invalid systematic_type {self.indata.systematic_type}, valid choices are 'log_normal' or 'normal'")
+        self.beta0.assign(self._default_beta0())
+
+    def betadefaultassign(self):
+        self.beta.assign(self.beta0)
 
     def defaultassign(self):
         self.cov.assign(self.prefit_covariance())
         self.theta0defaultassign()
-        self.beta0defaultassign()
+        if self.binByBinStat:
+            self.beta0defaultassign()
+            self.betadefaultassign()
         self.xdefaultassign()
 
     def bayesassign(self):
+        # FIXME use theta0 as the mean and constraintweight to scale the width
         if self.npoi == 0:
             self.x.assign(
                 self.theta0
@@ -174,10 +204,49 @@ class Fitter:
                 )
             )
 
+        if self.binByBinStat:
+            if self.binByBinStat_type == "gamma":
+                self.beta.assign(
+                    tf.random.gamma(
+                        shape=[],
+                        alpha=self.indata.kstat*self.beta0 + 1.0,
+                        beta=tf.ones_like(self.indata.kstat),
+                        dtype=self.beta.dtype,
+                    )/self.indata.kstat
+                )
+            elif self.binByBinStat_type == "normal":
+                self.beta.assign(
+                    tf.random.normal(
+                        shape=[],
+                        mean = self.beta0,
+                        sigma = tf.sqrt(self.varbeta),
+                        dtype=self.beta.dtype,
+                    )
+                )
+
     def frequentistassign(self):
+        # FIXME use theta as the mean and constraintweight to scale the width
         self.theta0.assign(
             tf.random.normal(shape=self.theta0.shape, dtype=self.theta0.dtype)
         )
+        if self.binByBinStat:
+            if self.binByBinStat_type == "gamma":
+                self.beta0.assign(
+                    tf.random.poisson(
+                        shape=[],
+                        lam=self.indata.kstat*self.beta,
+                        dtype=self.beta.dtype,
+                    )/self.indata.kstat
+                )
+            elif self.binByBinStat_type == "normal":
+                self.beta0.assign(
+                    tf.random.normal(
+                        shape=[],
+                        mean = self.beta,
+                        sigma = tf.sqrt(self.varbeta),
+                        dtype=self.beta.dtype,
+                    )
+                )
 
     def toyassign(self, bayesian=False, bootstrap_data=False):
         if bayesian:
@@ -187,28 +256,8 @@ class Fitter:
             # randomize nuisance constraint minima
             self.frequentistassign()
 
-        if self.binByBinStat:
-            # TODO properly implement randomization of constraint parameters associated with bin-by-bin stat nuisances for frequentist toys,
-            # currently bin-by-bin stat fluctuations are always handled in a bayesian way in toys
-            # this also means bin-by-bin stat fluctuations are not consistently propagated for bootstrap toys from data
-            raise NotImplementedError("binByBinStat not currently supported for toys")
-
-            # self.beta0.assign(
-            #     tf.random.gamma(
-            #         shape=[],
-            #         alpha=self.indata.kstat + 1.0,
-            #         beta=self.indata.kstat,
-            #         dtype=self.beta0.dtype,
-            #     )
-            # )
-
         if bootstrap_data:
             # randomize from observed data
-            if self.binByBinStat and not bayesian:
-                raise Exception(
-                    "Since bin-by-bin statistical uncertainties are always propagated in a bayesian manner, \
-                    they cannot currently be consistently propagated for bootstrap toys"
-                )
             self.nobs.assign(
                 tf.random.poisson(
                     lam=self.indata.data_obs, shape=[], dtype=self.nobs.dtype
@@ -226,6 +275,8 @@ class Fitter:
 
         # assign start values for nuisance parameters to constraint minima
         self.xdefaultassign()
+        if self.binByBinStat:
+            self.betadefaultassign()
         # set likelihood offset
         self.nexpnom.assign(self.expected_yield())
 
@@ -252,7 +303,7 @@ class Fitter:
         if self.binByBinStat:
             # impact bin-by-bin stat
             val_no_bbb, grad_no_bbb, hess_no_bbb = self.loss_val_grad_hess(
-                profile_grad=False
+                profile=False
             )
 
             hess_stat_no_bbb = hess_no_bbb[:nstat, :nstat]
@@ -319,9 +370,10 @@ class Fitter:
             dxdbeta0_noi = tf.gather(dxdbeta0[self.npoi :], self.indata.noigroupidxs)
             dxdbeta0 = tf.concat([dxdbeta0_poi, dxdbeta0_noi], axis=0)
 
+            # FIXME consider implications of using kstat*beta as the variance
             impacts_bbb = tf.sqrt(
                 tf.reduce_sum(
-                    tf.square(dxdbeta0) * tf.math.reciprocal(self.indata.kstat), axis=-1
+                    tf.square(dxdbeta0) * self.varbeta, axis=-1
                 )
             )
             impacts_bbb = tf.reshape(impacts_bbb, (-1, 1))
@@ -376,7 +428,8 @@ class Fitter:
 
         dtheta0 = tf.math.sqrt(var_theta0)
         dnobs = tf.math.sqrt(self.nobs)
-        dbeta0 = tf.math.sqrt(tf.math.reciprocal(self.indata.kstat))
+        # FIXME consider implications of using kstat*beta as the variance
+        dbeta0 = tf.math.sqrt(self.varbeta)
 
         dexpdtheta0 *= dtheta0[None, :]
         dexpdnobs *= dnobs[None, :]
@@ -501,7 +554,7 @@ class Fitter:
 
         expcov_noBBB = expcov
         if self.binByBinStat:
-            varbeta0 = tf.math.reciprocal(self.indata.kstat)
+            varbeta0 = self.varbeta
             exp_cov_BBB = pdexpdbeta0 @ (varbeta0[:, None] * tf.transpose(pdexpdbeta0))
             expcov += exp_cov_BBB
 
@@ -709,56 +762,55 @@ class Fitter:
         return nexpcentral, normcentral
 
     def _compute_yields_with_beta(
-        self, profile=True, profile_grad=True, compute_norm=False, full=True
+        self, profile=True, compute_norm=False, full=True
     ):
         nexp, norm = self._compute_yields_noBBB(compute_norm, full=full)
-
-        nexp_profile = nexp[: self.indata.nbins]
-        kstat = self.indata.kstat[: self.indata.nbins]
-        beta0 = self.beta0[: self.indata.nbins]
 
         if self.binByBinStat:
             if profile:
                 # analytic solution for profiled barlow-beeston lite parameters for each combination
                 # of likelihood and uncertainty form
+
+                nexp_profile = nexp[: self.indata.nbins]
+                kstat = self.indata.kstat[: self.indata.nbins]
+                beta0 = self.beta0[: self.indata.nbins]
+                # denominator in Gaussian likelihood is treated as a constant when computing
+                # global impacts for example
+                nobs0 = tf.stop_gradient(self.nobs)
+
                 if self.chisqFit:
-                    if self.indata.systematic_type == "log_normal":
+                    if self.binByBinStat_type == "gamma":
                         abeta = nexp_profile**2
-                        bbeta = kstat*self.nobs - nexp_profile*self.nobs
-                        cbeta = -kstat*self.nobs
+                        bbeta = kstat*nobs0 - nexp_profile*self.nobs
+                        cbeta = -kstat*nobs0*self.beta0
                         beta = 0.5*(-bbeta + tf.sqrt(bbeta**2 -4.*abeta*cbeta))/abeta
-                    elif self.indata.systematic_type == "normal":
-                        sigmabetasq = self.nobs**2/kstat
-                        beta = sigmabetasq*(self.nobs - nexp_profile)/(self.nobs + sigmabetasq)
-                    else:
-                        raise RuntimeError(f"Invalid systematic_type {self.indata.systematic_type}, valid choices are 'log_normal' or 'normal'")
+                    elif self.binByBinStat_type == "normal":
+                        if self.externalCovariance:
+                            beta = tf.linalg.lu_solve(self.betaauxlu, self.data_cov_inv @ ((self.nobs - nexp_profile)[:, None]) + (beta0/self.varbeta)[:, None])
+                            beta = tf.squeeze(beta, axis=-1)
+                        else:
+                            beta = (self.varbeta*(self.nobs - nexp_profile) + nobs0*beta0)/(nobs0 + self.varbeta)
                 else:
-                    if self.indata.systematic_type == "log_normal":
-                        beta = (self.nobs + kstat) / (
+                    if self.binByBinStat_type == "gamma":
+                        beta = (self.nobs + kstat*beta0) / (
                             nexp_profile + kstat
                         )
-                    elif self.indata.systematic_type == "normal":
-                        sigmabetasq = self.nobs**2/kstat
-                        bbeta = sigmabetasq + self.nobs
-                        cbeta = sigmabetasq*(nexp_profile - self.nobs)
+                    elif self.binByBinStat_type == "normal":
+                        bbeta = self.varbeta + nexp_profile - self.beta0
+                        cbeta = self.varbeta*(nexp_profile - self.nobs) - nexp_profile*self.beta0
                         beta = 0.5*(-bbeta + tf.sqrt(bbeta**2 -4.*cbeta))
-                    else:
-                        raise RuntimeError(f"Invalid systematic_type {self.indata.systematic_type}, valid choices are 'log_normal' or 'normal'")
 
-                if not profile_grad:
-                    beta = tf.stop_gradient(beta)
+                if full and self.indata.nbinsmasked:
+                    beta = tf.concat([beta, self.beta[self.indata.nbins :]], axis=0)
             else:
-                beta = beta0
+                beta = self.beta
+                if (not full) and self.indata.nbinsmasked:
+                    beta = beta[: self.indata.nbins]
 
-            if full and self.indata.nbinsmasked:
-                beta = tf.concat([beta, self.beta0[self.indata.nbins :]], axis=0)
-
-            if self.indata.systematic_type == "log_normal":
+            if self.binByBinStat_type == "gamma":
                 nexp = nexp*beta
-            elif self.indata.systematic_type == "normal":
+            elif self.binByBinStat_type == "normal":
                 nexp = nexp + beta
-            else:
-                raise RuntimeError(f"Invalid systematic_type {self.indata.systematic_type}, valid choices are 'log_normal' or 'normal'")
 
             if compute_norm:
                 norm = beta[..., None] * norm
@@ -772,12 +824,30 @@ class Fitter:
 
         return nexp, norm, beta
 
+    @tf.function
+    def _profile_beta(self):
+        nexp, norm, beta = self._compute_yields_with_beta()
+        self.beta.assign(beta)
+
+    @tf.function
+    def expected_events_nominal(self):
+        rnorm  = tf.ones(self.indata.nproc, dtype=self.indata.dtype)
+        mrnorm = tf.expand_dims(rnorm, -1)
+
+        if self.indata.sparse:
+            nexpfullcentral = tf.sparse.sparse_dense_matmul(self.indata.norm, mrnorm)
+            nexpfullcentral = tf.squeeze(nexpfullcentral, -1)
+        else:
+            nexpfullcentral = tf.matmul(self.indata.norm, mrnorm)
+            nexpfullcentral = tf.squeeze(nexpfullcentral, -1)
+
+        return nexpfullcentral
+
     def _compute_yields(
-        self, inclusive=True, profile=True, profile_grad=True, full=True
+        self, inclusive=True, profile=True, full=True
     ):
         nexpcentral, normcentral, beta = self._compute_yields_with_beta(
             profile=profile,
-            profile_grad=profile_grad,
             compute_norm=not inclusive,
             full=full,
         )
@@ -808,13 +878,12 @@ class Fitter:
         compute_variations=False,
         correlated_variations=False,
         profile=True,
-        profile_grad=True,
         compute_chi2=False,
     ):
 
         def fun():
             return self._compute_yields(
-                inclusive=inclusive, profile=profile, profile_grad=profile_grad
+                inclusive=inclusive, profile=profile,
             )
 
         if compute_variations and (
@@ -845,7 +914,6 @@ class Fitter:
                     self._compute_yields(
                         inclusive=inclusive,
                         profile=profile,
-                        profile_grad=profile_grad,
                         full=False,
                     )
                     - self.nobs
@@ -882,7 +950,6 @@ class Fitter:
         compute_variations=False,
         correlated_variations=False,
         profile=True,
-        profile_grad=True,
         compute_chi2=False,
         masked=False,
     ):
@@ -891,7 +958,6 @@ class Fitter:
             return self._compute_yields(
                 inclusive=inclusive,
                 profile=profile,
-                profile_grad=profile_grad,
                 full=masked,
             )
 
@@ -1012,10 +1078,15 @@ class Fitter:
         return dxdtheta0, dxdnobs, dxdbeta0
 
     @tf.function
-    def expected_yield(self, profile=False):
+    def expected_yield(self, profile=False, full=False):
         return self._compute_yields(
-            inclusive=True, profile=profile, profile_grad=False, full=False
+            inclusive=True, profile=profile, full=full
         )
+
+    @tf.function
+    def _expected_yield_noBBB(self, full=False):
+        res, _ = self._compute_yields_noBBB(full=full)
+        return res
 
     @tf.function
     def chi2(self, res, rescov):
@@ -1023,15 +1094,28 @@ class Fitter:
 
     @tf.function
     def saturated_nll(self):
+
         nobs = self.nobs
 
-        nobsnull = tf.equal(nobs, tf.zeros_like(nobs))
+        if self.chisqFit:
+            lsaturated = tf.zeros(shape=(), dtype=self.nobs.dtype)
+        else:
+            nobsnull = tf.equal(nobs, tf.zeros_like(nobs))
 
-        # saturated model
-        nobssafe = tf.where(nobsnull, tf.ones_like(nobs), nobs)
-        lognobs = tf.math.log(nobssafe)
+            # saturated model
+            nobssafe = tf.where(nobsnull, tf.ones_like(nobs), nobs)
+            lognobs = tf.math.log(nobssafe)
 
-        lsaturated = tf.reduce_sum(-nobs * lognobs + nobs, axis=-1)
+            lsaturated = tf.reduce_sum(-nobs * lognobs + nobs, axis=-1)
+
+        if self.binByBinStat:
+            if self.binByBinStat_type == "log_normal":
+                kstat = self.indata.kstat[: self.indata.nbins]
+                beta0 = self.beta0[: self.indata.nbins]
+                lsaturated += tf.reduce_sum(-kstat * beta0 * tf.math.log(beta0) + kstat*beta0)
+            elif self.binByBinStat_type == "normal":
+                # mc stat contribution to the saturated likelihood is zero in this case
+                pass
 
         ndof = (
             tf.size(nobs) - self.npoi - self.indata.nsystnoconstraint - self.normalize
@@ -1049,12 +1133,11 @@ class Fitter:
         l, lfull = self._compute_nll()
         return l
 
-    def _compute_nll(self, profile=True, profile_grad=True):
+    def _compute_nll(self, profile=True):
         theta = self.x[self.npoi :]
 
         nexpfullcentral, _, beta = self._compute_yields_with_beta(
             profile=profile,
-            profile_grad=profile_grad,
             compute_norm=False,
             full=False,
         )
@@ -1062,13 +1145,18 @@ class Fitter:
         nexp = nexpfullcentral
 
         if self.chisqFit:
-            residual = tf.reshape(self.nobs - nexp, [-1, 1])  # chi2 residual
-            # Solve the system without inverting
-            ln = lnfull = 0.5 * tf.reduce_sum(
-                tf.matmul(
-                    residual, tf.matmul(self.data_cov_inv, residual), transpose_a=True
+            if self.externalCovariance:
+                # Solve the system without inverting
+                residual = tf.reshape(self.nobs - nexp, [-1, 1])  # chi2 residual
+                ln = lnfull = 0.5 * tf.reduce_sum(
+                    tf.matmul(
+                        residual, tf.matmul(self.data_cov_inv, residual), transpose_a=True
+                    )
                 )
-            )
+            else:
+                # stop_gradient needed in denominator here because it should be considered
+                # constant when evaluating global impacts from observed data
+                ln = lnfull = 0.5*tf.math.reduce_sum((nexp - self.nobs)**2/tf.stop_gradient(self.nobs), axis=-1)
         else:
             nobsnull = tf.equal(self.nobs, tf.zeros_like(self.nobs))
 
@@ -1099,28 +1187,29 @@ class Fitter:
         if self.binByBinStat:
             kstat = self.indata.kstat[: self.indata.nbins]
             beta0 = self.beta0[: self.indata.nbins]
-            if self.indata.systematic_type == "log_normal":
+            if self.binByBinStat_type == "gamma":
                 lbetavfull = (
-                    -kstat * tf.math.log(beta / beta0)
-                    + kstat * beta / beta0
+                    -kstat * beta0 * tf.math.log(beta)
+                    + kstat * beta
                 )
 
-                lbetav = lbetavfull - kstat
-            elif self.indata.systematic_type == "normal":
-                lbetavfull = 0.5*(beta - beta0)**2*kstat/self.nobs**2
-                lbetav = lbetavfull
-            else:
-                raise RuntimeError(f"Invalid systematic_type {self.indata.systematic_type}, valid choices are 'log_normal' or 'normal'")
+                lbetav = -kstat * beta0 * tf.math.log(beta) + kstat * (beta - 1.)
 
-            lbeta = tf.reduce_sum(lbetav)
+                lbetafull = tf.reduce_sum(lbetavfull)
+                lbeta = tf.reduce_sum(lbetav)
+            elif self.binByBinStat_type == "normal":
+                lbetavfull = 0.5*(beta - beta0)**2/self.varbeta
+
+                lbetafull  = tf.reduce_sum(lbetavfull)
+                lbeta = lbetafull
 
             l = l + lbeta
-            lfull = lfull + lbeta
+            lfull = lfull + lbetafull
 
         return l, lfull
 
-    def _compute_loss(self, profile=True, profile_grad=True):
-        l, lfull = self._compute_nll(profile=profile, profile_grad=profile_grad)
+    def _compute_loss(self, profile=True):
+        l, lfull = self._compute_nll(profile=profile)
         return l
 
     @tf.function
@@ -1163,25 +1252,40 @@ class Fitter:
     loss_val_grad_hessp = loss_val_grad_hessp_revrev
 
     @tf.function
-    def loss_val_grad_hess(self, profile_grad=True):
+    def loss_val_grad_hess(self, profile=True):
         with tf.GradientTape() as t2:
             with tf.GradientTape() as t1:
-                val = self._compute_loss(profile_grad=profile_grad)
+                val = self._compute_loss(profile=profile)
             grad = t1.gradient(val, self.x)
         hess = t2.jacobian(grad, self.x)
 
         return val, grad, hess
 
+    @tf.function
+    def loss_val_valfull_grad_hess(self, profile=True):
+        with tf.GradientTape() as t2:
+            with tf.GradientTape() as t1:
+                val, valfull = self._compute_nll(profile=profile)
+            grad = t1.gradient(val, self.x)
+        hess = t2.jacobian(grad, self.x)
+
+        return val, valfull, grad, hess
+
     def minimize(self):
 
         if self.is_linear:
-            print("linear solve")
+            logger.info("Likelihood is purely quadratic, solving by Cholesky decomposition instead of iterative fit")
 
             # no need to do a minimization, simple matrix solve is sufficient
             val, grad, hess = self.loss_val_grad_hess()
 
             # use a Cholesky decomposition to easily detect the non-positive-definite case
             chol = tf.linalg.cholesky(hess)
+
+            # FIXME catch this exception to mark failed toys and continue
+            if tf.reduce_any(tf.math.is_nan(chol)).numpy():
+                raise ValueError("Cholesky decomposition failed, Hessian is not positive-definite")
+
             del hess
             gradv = grad[..., None]
             dx =  tf.linalg.cholesky_solve(chol, -gradv)[:, 0]
@@ -1200,16 +1304,41 @@ class Fitter:
                 val, grad, hessp = self.loss_val_grad_hessp(p)
                 return hessp.__array__()
 
+
+
+            class FitterCallback:
+                def __init__(self, xv):
+                    self.iiter = 0
+                    self.xval = xv
+
+                def __call__(self, intermediate_result):
+                    logger.debug(f"Iteration {self.iiter}: loss value {intermediate_result.fun}")
+                    self.xval = intermediate_result.x
+                    self.iiter += 1
+
             xval = self.x.numpy()
+            callback = FitterCallback(xval)
 
-            res = scipy.optimize.minimize(
-                scipy_loss, xval, method="trust-krylov", jac=True, hessp=scipy_hessp, tol=0.,
-            )
-
-            xval = res["x"]
+            try:
+                res = scipy.optimize.minimize(
+                    scipy_loss, xval, method="trust-krylov", jac=True, hessp=scipy_hessp, tol=0., callback=callback,
+                )
+            except Exception as ex:
+                # minimizer could have called the loss or hessp functions with "random" values, so restore the
+                # state from the end of the last iteration before the exception
+                xval = callback.xval
+                logger.debug(ex)
+            else:
+                xval = res["x"]
+                logger.debug(res)
 
             self.x.assign(xval)
-            print(res)
+
+        # force profiling of beta with final parameter values
+        # TODO avoid the extra calculation and jitting if possible since the relevant calculation
+        # usually would have been done during the minimization
+        if self.binByBinStat:
+            self._profile_beta()
 
     def nll_scan(self, param, scan_range, scan_points, use_prefit=False):
         # make a likelihood scan for a single parameter

--- a/combinetf2/fitter.py
+++ b/combinetf2/fitter.py
@@ -8,6 +8,17 @@ from combinetf2.tfhelpers import simple_sparse_slice0end
 logger = logging.child_logger(__name__)
 
 
+class FitterCallback:
+    def __init__(self, xv):
+        self.iiter = 0
+        self.xval = xv
+
+    def __call__(self, intermediate_result):
+        logger.debug(f"Iteration {self.iiter}: loss value {intermediate_result.fun}")
+        self.xval = intermediate_result.x
+        self.iiter += 1
+
+
 class Fitter:
     def __init__(self, indata, options):
         self.indata = indata
@@ -1320,18 +1331,6 @@ class Fitter:
                 p = tf.convert_to_tensor(pval)
                 val, grad, hessp = self.loss_val_grad_hessp(p)
                 return hessp.__array__()
-
-            class FitterCallback:
-                def __init__(self, xv):
-                    self.iiter = 0
-                    self.xval = xv
-
-                def __call__(self, intermediate_result):
-                    logger.debug(
-                        f"Iteration {self.iiter}: loss value {intermediate_result.fun}"
-                    )
-                    self.xval = intermediate_result.x
-                    self.iiter += 1
 
             xval = self.x.numpy()
             callback = FitterCallback(xval)

--- a/combinetf2/fitter.py
+++ b/combinetf2/fitter.py
@@ -706,10 +706,6 @@ class Fitter:
                 snormnorm_sparse = self.indata.norm.with_values(
                     self.indata.norm.values + logsnorm
                 )
-            else:
-                raise RuntimeError(
-                    f"Invalid systematic_type {self.indata.systematic_type}, valid choices are 'log_normal' or 'normal'"
-                )
 
             nexpfullcentral = tf.sparse.sparse_dense_matmul(snormnorm_sparse, mrnorm)
             nexpfullcentral = tf.squeeze(nexpfullcentral, -1)
@@ -753,10 +749,6 @@ class Fitter:
                 snormnorm = snorm * norm
             elif self.indata.systematic_type == "normal":
                 snormnorm = norm + logsnorm
-            else:
-                raise RuntimeError(
-                    f"Invalid systematic_type {self.indata.systematic_type}, valid choices are 'log_normal' or 'normal'"
-                )
 
             nexpcentral = tf.matmul(snormnorm, mrnorm)
             nexpcentral = tf.squeeze(nexpcentral, -1)

--- a/combinetf2/inputdata.py
+++ b/combinetf2/inputdata.py
@@ -121,7 +121,7 @@ class FitInputData:
 
             if self.metadata.get("exponential_transform", False):
                 raise NotImplementedError(
-                    "exponential_transform functionality has been removed.   Please use systematicType normal instead"
+                    "exponential_transform functionality has been removed.   Please use systematic_type normal instead"
                 )
 
             self.systematic_type = self.metadata.get("systematic_type", "log_normal")

--- a/combinetf2/inputdata.py
+++ b/combinetf2/inputdata.py
@@ -119,13 +119,10 @@ class FitInputData:
 
             self.symmetric_tensor = self.metadata.get("symmetric_tensor", False)
 
-            # TODO this should be deprecated in favor of systematic_type normal
-            self.exponential_transform = self.metadata.get(
-                "exponential_transform", False
-            )
-            self.exponential_transform_scale = self.metadata.get(
-                "exponential_transform_scale", 1000000
-            )
+            if self.metadata.get("exponential_transform", False):
+                raise NotImplementedError(
+                    "exponential_transform functionality has been removed.   Please use systematicType normal instead"
+                )
 
             self.systematic_type = self.metadata.get("systematic_type", "log_normal")
 

--- a/combinetf2/inputdata.py
+++ b/combinetf2/inputdata.py
@@ -118,12 +118,16 @@ class FitInputData:
                     }
 
             self.symmetric_tensor = self.metadata.get("symmetric_tensor", False)
+
+            # TODO this should be deprecated in favor of systematic_type normal
             self.exponential_transform = self.metadata.get(
                 "exponential_transform", False
             )
             self.exponential_transform_scale = self.metadata.get(
                 "exponential_transform_scale", 1000000
             )
+
+            self.systematic_type = self.metadata.get("systematic_type", "log_normal")
 
             # compute indices for channels
             ibin = 0

--- a/combinetf2/tensorwriter.py
+++ b/combinetf2/tensorwriter.py
@@ -15,7 +15,7 @@ class TensorWriter:
         self,
         sparse=False,
         exponential_transform=False,
-        systematic_type = "log_normal",
+        systematic_type="log_normal",
         allow_negative_expectation=False,
     ):
         self.allow_negative_expectation = allow_negative_expectation
@@ -297,7 +297,7 @@ class TensorWriter:
                 self.logkepsilon * np.ones_like(_logk),
             )
 
-            #FIXME does this actually take effect since _logk_view is normally returned?
+            # FIXME does this actually take effect since _logk_view is normally returned?
             if self.clipSystVariations > 0.0:
                 _logk = np.clip(_logk, -self.clip, self.clip)
             if self.exponential_transform:
@@ -305,10 +305,12 @@ class TensorWriter:
             else:
                 return _logk_view
         elif self.systematic_type == "normal":
-            _logk = kfac*(syst - norm)
+            _logk = kfac * (syst - norm)
             return _logk
         else:
-            raise RuntimeError(f"Invalid systematic_type {self.indata.systematic_type}, valid choices are 'log_normal' or 'normal'")
+            raise RuntimeError(
+                f"Invalid systematic_type {self.indata.systematic_type}, valid choices are 'log_normal' or 'normal'"
+            )
 
     def book_logk_avg(self, *args):
         self.book_logk(
@@ -671,7 +673,7 @@ class TensorWriter:
             "symmetric_tensor": self.symmetric_tensor,
             "exponential_transform": self.exponential_transform,
             "exponential_transform_scale": self.exponential_transform_scale,
-            "systematic_type" : self.systematic_type,
+            "systematic_type": self.systematic_type,
         }
 
         ioutils.pickle_dump_h5py("meta", meta, f)

--- a/combinetf2/tensorwriter.py
+++ b/combinetf2/tensorwriter.py
@@ -14,15 +14,10 @@ class TensorWriter:
     def __init__(
         self,
         sparse=False,
-        exponential_transform=False,
         systematic_type="log_normal",
         allow_negative_expectation=False,
     ):
         self.allow_negative_expectation = allow_negative_expectation
-        self.exponential_transform = exponential_transform
-        self.exponential_transform_scale = (
-            100000  # multiplier for the exponential transformed tensor
-        )
 
         self.systematic_type = systematic_type
 
@@ -287,10 +282,7 @@ class TensorWriter:
         # TODO clean this up and avoid duplication
         if self.systematic_type == "log_normal":
             # check if there is a sign flip between systematic and nominal
-            if self.exponential_transform:
-                _logk = kfac * (syst - norm) / self.exponential_transform_scale
-            else:
-                _logk = kfac * np.log(syst / norm)
+            _logk = kfac * np.log(syst / norm)
             _logk_view = np.where(
                 np.equal(np.sign(norm * syst), 1),
                 _logk,
@@ -300,10 +292,8 @@ class TensorWriter:
             # FIXME does this actually take effect since _logk_view is normally returned?
             if self.clipSystVariations > 0.0:
                 _logk = np.clip(_logk, -self.clip, self.clip)
-            if self.exponential_transform:
-                return _logk
-            else:
-                return _logk_view
+
+            return _logk_view
         elif self.systematic_type == "normal":
             _logk = kfac * (syst - norm)
             return _logk
@@ -444,9 +434,6 @@ class TensorWriter:
                     if proc not in dict_norm_chan:
                         continue
                     norm_proc = dict_norm_chan[proc]
-
-                    if self.exponential_transform:
-                        norm_proc = np.exp(norm_proc / self.exponential_transform_scale)
 
                     norm_indices = np.transpose(np.nonzero(norm_proc))
                     norm_values = np.reshape(norm_proc[norm_indices], [-1])
@@ -613,8 +600,6 @@ class TensorWriter:
                         continue
 
                     norm_proc = dict_norm_chan[proc]
-                    if self.exponential_transform:
-                        norm_proc = np.exp(norm_proc / self.exponential_transform_scale)
 
                     norm[ibin : ibin + nbinschan, iproc] = norm_proc
 
@@ -671,8 +656,6 @@ class TensorWriter:
             ),
             "channel_info": self.channels,
             "symmetric_tensor": self.symmetric_tensor,
-            "exponential_transform": self.exponential_transform,
-            "exponential_transform_scale": self.exponential_transform_scale,
             "systematic_type": self.systematic_type,
         }
 

--- a/tests/make_tensor.py
+++ b/tests/make_tensor.py
@@ -27,12 +27,6 @@ parser.add_argument(
     help="Make fully symmetric tensor",
 )
 parser.add_argument(
-    "--exponentialTransform",
-    default=False,
-    action="store_true",
-    help="Store tensor with exponential transformation",
-)
-parser.add_argument(
     "--skipMaskedChannels",
     default=False,
     action="store_true",
@@ -174,7 +168,6 @@ cov += np.diag(
 # Build tensor
 writer = tensorwriter.TensorWriter(
     sparse=args.sparse,
-    exponential_transform=args.exponentialTransform,
 )
 
 writer.add_channel(h1_data.axes, "ch0")


### PR DESCRIPTION
Add support for Gaussian systematic uncertainties (configured through the TensorWriter) and binByBin statistical uncertainties (configurable at run time)

The Gaussian binByBinStat case can now also be used with an externalCovarianceMatrix

In case the likelihood is purely quadratic it is now minimized by a matrix solve operations (via Cholesky decomposition) rather than an iterative fit.

Fit convergence criteria now tries to minimize the likelihood as much as possible within numerical precision.

Both bayesian and frequentist toys are now properly supported for binByBinStat.
Note that to accomplish this the "profile" options have been restructured again.  Since beta is now an explicit variable, a profiled central value with non-profiled gradients can be achieved with profile=False (since the correct values of beta are now set as part of the minimization procedure).  So the profile_grad option is no longer needed.
