### PR TITLE
Masked channel for data and cropping off masked channels in fit variables

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,6 +132,10 @@ jobs:
         run: >-
           python tests/make_tensor.py -o $COMBINETF2_OUTDIR/ --symmetrizeAll --postfix symmetric 
 
+      - name: make fully symmetric tensor
+        run: >-
+          python tests/make_tensor.py -o $COMBINETF2_OUTDIR/ --symmetrizeAll --noSignal --systematicType normal --postfix linear 
+
       - name: make sparse tensor
         run: >-
           python tests/make_tensor.py -o $COMBINETF2_OUTDIR/ --sparse --postfix sparse
@@ -166,6 +170,12 @@ jobs:
         run: >- 
           combinetf2_fit.py $COMBINETF2_OUTDIR/test_tensor.hdf5 -o $COMBINETF2_OUTDIR/
           -t 0 --binByBinStat --doImpacts --globalImpacts --project ch1 a --project ch1 b --project ch0_masked
+          --saveHists --saveHistsPerProcess --computeHistErrors --computeHistCov --computeHistImpacts --computeVariations
+
+      - name: linear solution
+        run: >- 
+          combinetf2_fit.py $COMBINETF2_OUTDIR/test_tensor.hdf5 -o $COMBINETF2_OUTDIR/ --postfix linear
+          -t -1 0 --binByBinStat --binByBinStatType normal --chisqFit --doImpacts --globalImpacts
           --saveHists --saveHistsPerProcess --computeHistErrors --computeHistCov --computeHistImpacts --computeVariations
 
       - name: sparse tensor fit 

--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ source setup.sh
 
 An example can be found in ```tests/make_tensor.py -o test_tensor.hdf5```. 
 
-### Systematic uncertainties
-Systematic uncertainties are implemented by default using a log-normal probability density (with a multiplicative effect on the event yield).  Gaussian uncertainties with an additive effect on the event yield can also be used.  This is configured through the `systematic_type` parameter of the `TensorWriter`.
-
 ### Sparse tensor
 By setting `sparse=True` in the `TensorWriter` constructor the tensor is stored in the sparse representation. 
 This is useful when working with a sparse tensor, e.g. having many bins/processes/systematics where each bin/process/systematic only contributes to a small number of bins/processes/systematics. 
 This is often the case in the standard profile likelihood unfolding. 
+
+### Systematic uncertainties
+Systematic uncertainties are implemented by default using a log-normal probability density (with a multiplicative effect on the event yield). Gaussian uncertainties with an additive effect on the event yield can also be used. This is configured through the `systematic_type` parameter of the `TensorWriter`.
 
 ### Symmetrization
 By default, systematic variations are asymmetric. 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ If a systematic variation is added by providing a single histogram, the variatio
 ### Masked channels
 Masked channels can be added that don't contribute to the likelihood but are evaluated as any other channel. 
 This is done by defining `masked=True` in the `tensorwriter` `add_channel` function. 
-(Pseudo) Data histograms for masked channels are not supported.
+(Pseudo) Data histograms for masked channels can be provided for convenience optionally but are not used anywhere in the fit.
 This is useful for example to compute unfolded (differential) cross sections and their uncertainties, including global impacts, taking into account all nuisance parameters that affect these channels.
 
 ## Run the fit

--- a/bin/combinetf2_fit.py
+++ b/bin/combinetf2_fit.py
@@ -619,7 +619,7 @@ def main():
             group = "results"
             if ifit == -1:
                 group += "_asimov"
-                ifitter.nobs.assign(ifitter.expected_yield())
+                ifitter.nobs.assign(ifitter.expected_events_nominal())
             if ifit == 0:
                 ifitter.nobs.assign(ifitter.indata.data_obs)
             elif ifit >= 1:

--- a/bin/combinetf2_fit.py
+++ b/bin/combinetf2_fit.py
@@ -619,9 +619,9 @@ def main():
             group = "results"
             if ifit == -1:
                 group += "_asimov"
-                ifitter.nobs.assign(ifitter.expected_events_nominal())
+                ifitter.nobsassign(asimov=True)
             if ifit == 0:
-                ifitter.nobs.assign(ifitter.indata.data_obs)
+                ifitter.nobsassign()
             elif ifit >= 1:
                 group += f"_toy{ifit}"
                 ifitter.toyassign(

--- a/combinetf2/fitter.py
+++ b/combinetf2/fitter.py
@@ -93,7 +93,7 @@ class Fitter:
 
         # observed number of events per bin
         self.nobs = tf.Variable(
-            self.expected_events_nominal(), trainable=False, name="nobs"
+            self.indata.data_obs[: self.indata.nbins], trainable=False, name="nobs"
         )
 
         if self.chisqFit:
@@ -126,8 +126,8 @@ class Fitter:
         self.beta = tf.Variable(self.beta0, trainable=False, name="beta")
 
         # cache the constraint variance since it's used in several places
-        n0 = self.expected_events_nominal()
         # this is treated as a constant
+        n0 = self.expected_events_nominal()
         if self.binByBinStatType == "gamma":
             self.varbeta = tf.stop_gradient(
                 tf.math.reciprocal(self.indata.kstat[: self.indata.nbins])

--- a/tests/make_tensor.py
+++ b/tests/make_tensor.py
@@ -21,6 +21,18 @@ parser.add_argument(
     help="Make sparse tensor",
 )
 parser.add_argument(
+    "--noSignal",
+    default=False,
+    action="store_true",
+    help="Don't assign signal strength to signal process",
+)
+parser.add_argument(
+    "--systematicType",
+    default="log_normal",
+    choices=["log_normal", "normal"],
+    help="How variations are applied",
+)
+parser.add_argument(
     "--symmetrizeAll",
     default=False,
     action="store_true",
@@ -32,7 +44,6 @@ parser.add_argument(
     action="store_true",
     help="Skip adding masked channels",
 )
-
 
 args = parser.parse_args()
 
@@ -168,6 +179,7 @@ cov += np.diag(
 # Build tensor
 writer = tensorwriter.TensorWriter(
     sparse=args.sparse,
+    systematic_type=args.systematicType,
 )
 
 writer.add_channel(h1_data.axes, "ch0")
@@ -181,8 +193,8 @@ writer.add_pseudodata(h2_pseudo, "original", "ch1")
 
 writer.add_data_covariance(cov)
 
-writer.add_process(h1_sig, "sig", "ch0", signal=True)
-writer.add_process(h2_sig, "sig", "ch1", signal=True)
+writer.add_process(h1_sig, "sig", "ch0", signal=not args.noSignal)
+writer.add_process(h2_sig, "sig", "ch1", signal=not args.noSignal)
 
 writer.add_process(h1_bkg, "bkg", "ch0")
 writer.add_process(h2_bkg, "bkg", "ch1")
@@ -192,7 +204,7 @@ writer.add_process(h1_bkg_2, "bkg_2", "ch0")
 if not args.skipMaskedChannels:
     # add masked channel
     writer.add_channel(h1_sig_masked.axes, "ch0_masked", masked=True)
-    writer.add_process(h1_sig_masked, "sig", "ch0_masked", signal=True)
+    writer.add_process(h1_sig_masked, "sig", "ch0_masked", signal=not args.noSignal)
 
 # systematic uncertainties
 


### PR DESCRIPTION
- Allow masked channel with data for convenience, to propagate data histogram into result and plotting
- Add test for fully linear model in CI
- In the fitter class variables that are only needed in the actual fit but not for the masked channels are defined w/o masked channel (beta, beta0, betavar, betaauxlu, nobs, nexpnom). This also fix small issues with fully linear model when used together with masked channels