### PR TITLE
Option to absorb systematics into data covariance, and additional flexibility for toys

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ python -m venv env
 The activate it and install the necessary packages
 ```bash
 source env/bin/activate
-pip install wums[pickling,plotting] tensorflow numpy h5py hist scipy matplotlib mplhep seaborn pandas plotly kaleido
+pip install wums[pickling,plotting] tensorflow tensorflow-probability numpy h5py hist scipy matplotlib mplhep seaborn pandas plotly kaleido
 ```
 The packages `matplotlib`, `mplhep`, `seaborn`, `pandas`, `plotly`, and `kaleido` are only needed for the plotting scripts. 
 In case you want to contribute to the development, please also install the linters `isort`, `flake8`, `autoflake`, `black`, and `pylint` used in the pre-commit hooks and the github CI

--- a/bin/combinetf2_fit.py
+++ b/bin/combinetf2_fit.py
@@ -54,16 +54,28 @@ def make_parser():
         help="run a given number of toys, 0 fits the data, and -1 fits the asimov toy (the default)",
     )
     parser.add_argument(
-        "--toysBayesian",
-        default=False,
-        action="store_true",
-        help="run bayesian-type toys (otherwise frequentist)",
+        "--toysSystRandomize",
+        default="frequentist",
+        choices=["frequentist", "bayesian", "none"],
+        help="Type of randomization for systematic uncertainties (including binByBinStat if present).  Options are 'frequentist' which randomizes the contraint minima a.k.a global observables and 'bayesian' which randomizes the actual nuisance parameters used in the pseudodata generation",
     )
     parser.add_argument(
-        "--bootstrapData",
+        "--toysDataRandomize",
+        default="poisson",
+        choices=["poisson", "normal", "none"],
+        help="Type of randomization for pseudodata.  Options are 'poisson',  'normal', and 'none'",
+    )
+    parser.add_argument(
+        "--toysDataMode",
+        default="expected",
+        choices=["expected", "observed"],
+        help="central value for pseudodata used in the toys",
+    )
+    parser.add_argument(
+        "--toysRandomizeParameters",
         default=False,
         action="store_true",
-        help="throw toys directly from observed data counts rather than expectation from templates",
+        help="randomize the parameter starting values for toys",
     )
     parser.add_argument(
         "--seed", default=123456789, type=int, help="random seed for toys"
@@ -251,6 +263,12 @@ def make_parser():
         default=False,
         action="store_true",
         help="Using an external covariance matrix for the observations in the chi-square fit",
+    )
+    parser.add_argument(
+        "--prefitUnconstrainedNuisanceUncertainty",
+        default=0.0,
+        type=float,
+        help="Assumed prefit uncertainty for unconstrained nuisances",
     )
 
     return parser.parse_args()
@@ -625,7 +643,10 @@ def main():
             elif ifit >= 1:
                 group += f"_toy{ifit}"
                 ifitter.toyassign(
-                    bayesian=args.toysBayesian, bootstrap_data=args.bootstrapData
+                    syst_randomize=args.toysSystRandomize,
+                    data_randomize=args.toysDataRandomize,
+                    data_mode=args.toysDataMode,
+                    randomize_parameters=args.toysRandomizeParameters,
                 )
 
             ws.add_parms_hist(

--- a/combinetf2/tfhelpers.py
+++ b/combinetf2/tfhelpers.py
@@ -23,3 +23,9 @@ def simple_sparse_slice0end(in_sparse, end):
     return tf.sparse.SparseTensor(
         indices=selected_indices, values=selected_values, dense_shape=out_shape
     )
+
+
+def is_diag(x):
+    return tf.math.equal(
+        tf.math.count_nonzero(x), tf.math.count_nonzero(tf.linalg.diag_part(x))
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ requires-python = ">=3.8"
 
 dependencies = [
     "tensorflow",
+    "tensorflow-probability",
     "wums",
     "numpy",
     "h5py",


### PR DESCRIPTION
Adds the possibility to absorb systematic uncertainties into the data covariance matrix.  The associated code changes also fix https://github.com/WMass/combinetf2/issues/17 such that noi and unconstrained nuisances are now properly decoupled and can be configured separately in any combination.

Options for configuring toys are reorganized and made more flexible, to allow skipping randomization of systematic uncertainties and/or pseudodata entirely.  External covariance matrix is now consistently supported, and an option is added to randomize the starting values of the parameters.