### PR TITLE
Add minimizer fit and debug options

### DIFF
--- a/bin/combinetf2_fit.py
+++ b/bin/combinetf2_fit.py
@@ -47,6 +47,13 @@ def make_parser():
         help="Postfix to append on output file name",
     )
     parser.add_argument(
+        "--minimizerMethod",
+        default="trust-krylov",
+        type=str,
+        choices=["trust-krylov", "trust-exact"],
+        help="Mnimizer method used in scipy.optimize.minimize for the nominal fit minimization",
+    )
+    parser.add_argument(
         "-t",
         "--toys",
         default=[-1],

--- a/bin/combinetf2_fit.py
+++ b/bin/combinetf2_fit.py
@@ -38,6 +38,11 @@ def make_parser():
         default=False,
         help="Run tensorflow in eager mode (for debugging)",
     )
+    parser.add_argument(
+        "--diagnostics",
+        action="store_true",
+        help="Calculate and print additional info for diagnostics (condition number, edm value)",
+    )
     parser.add_argument("filename", help="filename of the main hdf5 input")
     parser.add_argument("-o", "--output", default="./", help="output directory")
     parser.add_argument("--outname", default="fitresults.hdf5", help="output file name")

--- a/bin/combinetf2_plot_inputdata.py
+++ b/bin/combinetf2_plot_inputdata.py
@@ -74,6 +74,12 @@ def parseArgs():
         "--dataName", type=str, default="Data", help="Data name for plot labeling"
     )
     parser.add_argument(
+        "--xlabel", type=str, default=None, help="x-axis label for plot labeling"
+    )
+    parser.add_argument(
+        "--ylabel", type=str, default=None, help="y-axis label for plot labeling"
+    )
+    parser.add_argument(
         "--processGrouping", type=str, default=None, help="key for grouping processes"
     )
 
@@ -290,6 +296,9 @@ def make_plot(
         binwnorm = None
         ylabel = "Events/bin"
 
+    if args.ylabel is not None:
+        ylabel = args.ylabel
+
     if len(axes_names) == 1:
         fu = lambda h: h.project(*axes_names)
     else:
@@ -301,7 +310,7 @@ def make_plot(
     if hist_data is not None:
         h_data = fu(hist_data)
 
-    xlabel = plot_tools.get_axis_label(config, axes_names, axes_names)
+    xlabel = plot_tools.get_axis_label(config, axes_names, args.xlabel)
 
     if args.splitByProcess:
         hists_pred = h_stack
@@ -465,20 +474,19 @@ def make_plot(
                 if key == "charge":
                     label = f"charge = {'-1' if hi==0 else '+1'}"
                 else:
-                    xlabel = plot_tools.get_axis_label(config, key, args.xlabel)
+                    label = plot_tools.get_axis_label(config, key, key)
                     if lo != None:
                         label = f"{lo} < {label}"
                     if hi != None:
                         label = f"{label} < {hi}"
 
-                ax1.text(
+                plot_tools.wrap_text(
+                    [label],
+                    ax1,
                     0.05,
                     0.96 - i * 0.08,
-                    label,
-                    horizontalalignment="left",
-                    verticalalignment="top",
-                    transform=ax1.transAxes,
-                    fontsize=20 * args.scaleleg * scale,
+                    ha="left",
+                    text_size="small",
                 )
 
         if not args.noRatio:
@@ -642,9 +650,8 @@ def main():
                 else:
                     h_data = None
 
-                if len(systematics):
-                    hs_syst_dn = [h[idxs] for h in hists_syst_dn]
-                    hs_syst_up = [h[idxs] for h in hists_syst_up]
+                hs_syst_dn = [h[idxs] for h in hists_syst_dn]
+                hs_syst_up = [h[idxs] for h in hists_syst_up]
 
                 make_plots(
                     args,

--- a/bin/debug_inutdata.py
+++ b/bin/debug_inutdata.py
@@ -82,7 +82,6 @@ def debug_input_data(input_file, output_dir=None, verbose=False, channels=None):
             idxs = np.where(hist_obj.values() < threshold)
             low_data_bins = idxs
 
-        if low_data_bins:
             issues_found += 1
             logger.info(
                 f"✗ Found {len(low_data_bins)} bins in channel {channel} with less than {threshold} data observations:"

--- a/combinetf2/fitter.py
+++ b/combinetf2/fitter.py
@@ -57,6 +57,7 @@ class Fitter:
                 f"Invalid systematic_type {self.indata.systematic_type}, valid choices are 'log_normal' or 'normal'"
             )
 
+        self.diagnostics = options.diagnostics
         self.minimizer_method = options.minimizerMethod
 
         self.chisqFit = options.chisqFit
@@ -1278,11 +1279,11 @@ class Fitter:
             def scipy_hess(xval):
                 self.x.assign(xval)
                 val, grad, hess = self.loss_val_grad_hess()
-                if logger.isEnabledFor(logging.logging.DEBUG):
+                if self.diagnostics:
                     cond_number = tfh.cond_number(hess)
-                    logger.debug(f"  - Condition number: {cond_number}")
+                    logger.info(f"  - Condition number: {cond_number}")
                     edmval = tfh.edmval(grad, hess)
-                    logger.debug(f"  - edmval: {edmval}")
+                    logger.info(f"  - edmval: {edmval}")
                 return hess.__array__()
 
             xval = self.x.numpy()

--- a/combinetf2/fitter.py
+++ b/combinetf2/fitter.py
@@ -143,7 +143,10 @@ class Fitter:
                 # precompute decomposition of composite matrix to speed up
                 # calculation of profiled beta values
                 self.betaauxlu = tf.linalg.lu(
-                    self.data_cov_inv + tf.linalg.diag(tf.math.reciprocal(self.varbeta))
+                    self.data_cov_inv
+                    + tf.linalg.diag(
+                        tf.math.reciprocal(self.varbeta[: self.indata.nbins])
+                    )
                 )
 
         self.nexpnom = tf.Variable(
@@ -851,6 +854,7 @@ class Fitter:
                 nexp_profile = nexp[: self.indata.nbins]
                 kstat = self.indata.kstat[: self.indata.nbins]
                 beta0 = self.beta0[: self.indata.nbins]
+                varbeta = self.varbeta[: self.indata.nbins]
                 # denominator in Gaussian likelihood is treated as a constant when computing
                 # global impacts for example
                 nobs0 = tf.stop_gradient(self.nobs)
@@ -859,7 +863,7 @@ class Fitter:
                     if self.binByBinStatType == "gamma":
                         abeta = nexp_profile**2
                         bbeta = kstat * nobs0 - nexp_profile * self.nobs
-                        cbeta = -kstat * nobs0 * self.beta0
+                        cbeta = -kstat * nobs0 * beta0
                         beta = (
                             0.5
                             * (-bbeta + tf.sqrt(bbeta**2 - 4.0 * abeta * cbeta))
@@ -871,22 +875,20 @@ class Fitter:
                                 *self.betaauxlu,
                                 self.data_cov_inv
                                 @ ((self.nobs - nexp_profile)[:, None])
-                                + (beta0 / self.varbeta)[:, None],
+                                + (beta0 / varbeta)[:, None],
                             )
                             beta = tf.squeeze(beta, axis=-1)
                         else:
                             beta = (
-                                self.varbeta * (self.nobs - nexp_profile)
-                                + nobs0 * beta0
-                            ) / (nobs0 + self.varbeta)
+                                varbeta * (self.nobs - nexp_profile) + nobs0 * beta0
+                            ) / (nobs0 + varbeta)
                 else:
                     if self.binByBinStatType == "gamma":
                         beta = (self.nobs + kstat * beta0) / (nexp_profile + kstat)
                     elif self.binByBinStatType == "normal":
-                        bbeta = self.varbeta + nexp_profile - self.beta0
+                        bbeta = varbeta + nexp_profile - beta0
                         cbeta = (
-                            self.varbeta * (nexp_profile - self.nobs)
-                            - nexp_profile * self.beta0
+                            varbeta * (nexp_profile - self.nobs) - nexp_profile * beta0
                         )
                         beta = 0.5 * (-bbeta + tf.sqrt(bbeta**2 - 4.0 * cbeta))
 
@@ -1149,6 +1151,7 @@ class Fitter:
         if self.binByBinStat:
             kstat = self.indata.kstat[: self.indata.nbins]
             beta0 = self.beta0[: self.indata.nbins]
+            varbeta = self.varbeta[: self.indata.nbins]
             if self.binByBinStatType == "gamma":
                 lbetavfull = -kstat * beta0 * tf.math.log(beta) + kstat * beta
 
@@ -1157,7 +1160,7 @@ class Fitter:
                 lbetafull = tf.reduce_sum(lbetavfull)
                 lbeta = tf.reduce_sum(lbetav)
             elif self.binByBinStatType == "normal":
-                lbetavfull = 0.5 * (beta - beta0) ** 2 / self.varbeta
+                lbetavfull = 0.5 * (beta - beta0) ** 2 / varbeta
 
                 lbetafull = tf.reduce_sum(lbetavfull)
                 lbeta = lbetafull

--- a/combinetf2/scipyhelpers.py
+++ b/combinetf2/scipyhelpers.py
@@ -31,16 +31,14 @@ def cho_inv(chol, overwrite_a=False, check_finite=True):
 
 
 def scipy_edmval_cov(grad, hess):
-    hess = hess.__array__()
     # FIXME catch this exception to mark failed toys and continue
     try:
-        chol = cho_factor_clean(hess.__array__(), lower=False)
+        chol = cho_factor_clean(hess, lower=False)
     except scipy.linalg.LinAlgError:
         raise ValueError(
             "Cholesky decomposition failed, Hessian is not positive-definite"
         )
 
-    grad = grad.__array__()
     gradv = grad[..., None]
     edmval = 0.5 * gradv.T @ scipy.linalg.cho_solve(chol, gradv)
     edmval = edmval[0, 0]
@@ -48,3 +46,14 @@ def scipy_edmval_cov(grad, hess):
     cov = cho_inv(chol, overwrite_a=True)
 
     return edmval, cov
+
+
+def scipy_edmval(grad, hess):
+    x = np.linalg.solve(hess, grad)
+    edmval = 0.5 * np.dot(grad, x)
+
+    return edmval
+
+
+def scipy_cond_number(hess):
+    return np.linalg.cond(hess)


### PR DESCRIPTION
- Add option to set minimizer method for fit (currently supported 'trust-krylov' and 'trust-exact' 
- For trust-exact hessian is needed and when used together with debug '-v 4' the condition number and edmval is calculated and printed
- Work on tf and scipy helper functions, 
  - only do the '__array__()' view when calling the scipy helper from the tf helper and not in the scipy helper itself since it's only needed when passing a tf tensor and not with a np.array.
- Improvements in the scripts to debug the inputdata tensor

This is on top of PR #26 