### PR TITLE
fix saturated nll with updated mc stat handling

### DIFF
--- a/combinetf2/fitter.py
+++ b/combinetf2/fitter.py
@@ -1191,8 +1191,8 @@ class Fitter:
 
         if self.binByBinStat:
             if self.binByBinStatType == "gamma":
-                kstat = self.kstat[: self.indata.nbins]
-                beta0 = self.beta0[: self.indata.nbins]
+                kstat = self.kstat
+                beta0 = self.beta0
                 lsaturated += tf.reduce_sum(
                     -kstat * beta0 * tf.math.log(beta0) + kstat * beta0
                 )


### PR DESCRIPTION
After https://github.com/WMass/combinetf2/pull/29 the saturated nll was inconsistent in the presence of gamma type binByBinStat in the presence of masked channels.

(The masked channel contribution was included in the nominal likelihood but not the saturated one)