### PR TITLE
add protection for inconsistent prefit global impact

### DIFF
--- a/combinetf2/fitter.py
+++ b/combinetf2/fitter.py
@@ -705,6 +705,15 @@ class Fitter:
                 # d2lcdx2 is diagonal so we can use gradient instead of jacobian
                 d2lcdx2_diag = t2.gradient(dlcdx, self.x)
 
+            # protect against inconsistency
+            # FIXME this should be handled more generally e.g. through modification of
+            # the constraintweights for prefit vs postfit, though special handling of the zero
+            # uncertainty case would still be needed
+            if (not profile) and self.prefitUnconstrainedNuisanceUncertainty != 0.0:
+                raise NotImplementedError(
+                    "Global impacts calculation not implemented for prefit case where prefitUnconstrainedNuisanceUncertainty != 0."
+                )
+
             # sc is the cholesky decomposition of d2lcdx2
             sc = tf.linalg.LinearOperatorDiag(
                 tf.sqrt(d2lcdx2_diag), is_self_adjoint=True


### PR DESCRIPTION
If overriding prefitUnconstrainedNuisanceUncertainty then prefit global impacts would be inconsistent.

Proper solution here is not completely trivial so just add a protection for now.