### PR TITLE
Fix binByBinStat profiling for case of Poisson likelihood and binByBinStatType normal (and add diangostics)

### DIFF
--- a/bin/combinetf2_fit.py
+++ b/bin/combinetf2_fit.py
@@ -425,6 +425,15 @@ def fit(args, fitter, ws, dofit=True):
 
         del cov
 
+        if fitter.binByBinStat and fitter.diagnostics:
+            # This is the estimated distance to minimum with respect to variations of
+            # the implicit binByBinStat nuisances beta at fixed parameter values.
+            # It should be near-zero by construction as long as the analytic profiling is
+            # correct
+            _, gradbeta, hessbeta = fitter.loss_val_grad_hess_beta()
+            edmvalbeta, covbeta = edmval_cov(gradbeta, hessbeta)
+            logger.info(f"edmvalbeta: {edmvalbeta}")
+
         if args.doImpacts:
             ws.add_impacts_hists(*fitter.impacts_parms(hess))
 

--- a/combinetf2/fitter.py
+++ b/combinetf2/fitter.py
@@ -1371,6 +1371,18 @@ class Fitter:
 
         return val, valfull, grad, hess
 
+    @tf.function
+    def loss_val_grad_hess_beta(self, profile=True):
+        with tf.GradientTape() as t2:
+            t2.watch(self.ubeta)
+            with tf.GradientTape() as t1:
+                t1.watch(self.ubeta)
+                val = self._compute_loss(profile=profile)
+            grad = t1.gradient(val, self.ubeta)
+        hess = t2.jacobian(grad, self.ubeta)
+
+        return val, grad, hess
+
     def minimize(self):
 
         if self.is_linear:

--- a/combinetf2/fitter.py
+++ b/combinetf2/fitter.py
@@ -989,7 +989,11 @@ class Fitter:
                         cbeta = (
                             sbeta * (nexp_profile - self.nobs) - nexp_profile * beta0
                         )
-                        beta = 0.5 * (-bbeta + tf.sqrt(bbeta**2 - 4.0 * cbeta)) / abeta
+                        beta = (
+                            0.5
+                            * (-bbeta + tf.sqrt(bbeta**2 - 4.0 * abeta * cbeta))
+                            / abeta
+                        )
                         beta = tf.where(varbeta == 0.0, beta0, beta)
 
                 if self.indata.nbinsmasked:


### PR DESCRIPTION
The specific case of binByBinStatType normal with Poisson likelihood had a bug in the profiling (introduced in https://github.com/WMass/combinetf2/pull/30)

This is fixed now, and additional diagnostics are added (triggered by the existing --diagnostics option) to explicitly compute and print the edmval with respect to the binByBinStat nuisances

