### PR TITLE
Fix chi2 calculation

### DIFF
--- a/bin/combinetf2_plot_hists.py
+++ b/bin/combinetf2_plot_hists.py
@@ -1258,8 +1258,11 @@ def main():
             chi2, ndf, saturated_chi2 = get_chi2(
                 (
                     fitresult
-                    if (instance_key == "Basemodel" and args.chisq != "linear")
-                    or args.chisq == "saturated"
+                    if fittype == "postfit"
+                    and (
+                        (instance_key == "Basemodel" and args.chisq != "linear")
+                        or args.chisq == "saturated"
+                    )
                     else instance
                 ),
                 args.chisq in [" ", "none", None],

--- a/bin/combinetf2_plot_hists_cov.py
+++ b/bin/combinetf2_plot_hists_cov.py
@@ -249,7 +249,9 @@ def main():
             model_key = " ".join(margs)
             instance_keys = [k for k in results.keys() if k.startswith(model_key)]
             if len(instance_keys) == 0:
-                raise ValueError(f"No model found under {model_key}")
+                raise ValueError(
+                    f"No model found under {model_key}, available models are {results.keys()}"
+                )
 
         for instance_key in instance_keys:
             instance = results[instance_key]

--- a/combinetf2/fitter.py
+++ b/combinetf2/fitter.py
@@ -1148,9 +1148,7 @@ class Fitter:
             var_beta0 = pd2ldbeta2 / pd2lbetadbetadbeta0**2
 
             if self.binByBinStatType == "gamma":
-                var_beta0 = tf.where(
-                    self.betamask, tf.constant(0.0, dtype=var_beta0.dtype), var_beta0
-                )
+                var_beta0 = tf.where(self.betamask, tf.zeros_like(var_beta0), var_beta0)
 
             res_cov_BBB = dresdbeta0 @ (var_beta0[:, None] * tf.transpose(dresdbeta0))
             res_cov += res_cov_BBB

--- a/combinetf2/fitter.py
+++ b/combinetf2/fitter.py
@@ -476,7 +476,7 @@ class Fitter:
                     _1, _2, beta = self._compute_yields_with_beta(
                         profile=True, compute_norm=False, full=False
                     )
-                    lbeta, _ = self._compute_lbeta(beta, profile=True)
+                    lbeta, _ = self._compute_lbeta(beta)
                 pdlbetadbeta = t1.gradient(lbeta, self.ubeta)
                 dlcdx = t1.gradient(lc, self.x)
                 dbetadx = t1.jacobian(beta, self.x)
@@ -556,7 +556,7 @@ class Fitter:
                         _1, _2, beta = self._compute_yields_with_beta(
                             profile=True, compute_norm=False, full=False
                         )
-                        lbeta, _ = self._compute_lbeta(beta, profile=True)
+                        lbeta, _ = self._compute_lbeta(beta)
                         val = lc + lbeta
                     else:
                         val = lc
@@ -798,7 +798,7 @@ class Fitter:
                         _1, _2, beta = self._compute_yields_with_beta(
                             profile=True, compute_norm=False, full=False
                         )
-                        lbeta, _ = self._compute_lbeta(beta, profile=True)
+                        lbeta, _ = self._compute_lbeta(beta)
                     pdlbetadbeta = t1.gradient(lbeta, self.ubeta)
                     dlcdx = t1.gradient(lc, self.x)
                     dbetadx = t1.jacobian(beta, self.x)
@@ -1286,7 +1286,7 @@ class Fitter:
         )
         return lc
 
-    def _compute_lbeta(self, beta, profile=True):
+    def _compute_lbeta(self, beta):
         if self.binByBinStat:
             beta0 = self.beta0
             if self.binByBinStatType == "gamma":
@@ -1355,7 +1355,7 @@ class Fitter:
 
         lc = lcfull = self._compute_lc()
 
-        lbeta, lbetafull = self._compute_lbeta(beta, profile)
+        lbeta, lbetafull = self._compute_lbeta(beta)
 
         return ln, lc, lbeta, lnfull, lcfull, lbetafull, beta
 

--- a/combinetf2/io_tools.py
+++ b/combinetf2/io_tools.py
@@ -110,6 +110,10 @@ def get_postfit_hist_cov(fitresult, physics_model="Basemodel", channels=None):
     """
     print(f"Load postfit histogram and covariance matrix")
 
+    if physics_model not in fitresult["physics_models"].keys():
+        raise IOError(
+            f"{physics_model} not found in fitresults, available models are {fitresult["physics_models"].keys()}"
+        )
     result = fitresult["physics_models"][physics_model]
 
     cov = result["hist_postfit_inclusive_cov"].get().values()

--- a/combinetf2/io_tools.py
+++ b/combinetf2/io_tools.py
@@ -112,7 +112,7 @@ def get_postfit_hist_cov(fitresult, physics_model="Basemodel", channels=None):
 
     if physics_model not in fitresult["physics_models"].keys():
         raise IOError(
-            f"{physics_model} not found in fitresults, available models are {fitresult["physics_models"].keys()}"
+            f"{physics_model} not found in fitresults, available models are {fitresult['physics_models'].keys()}"
         )
     result = fitresult["physics_models"][physics_model]
 

--- a/combinetf2/physicsmodels/physicsmodel.py
+++ b/combinetf2/physicsmodels/physicsmodel.py
@@ -58,8 +58,10 @@ class PhysicsModel:
             cov_output = (jacobian * data) @ tf.transpose(jacobian)
         else:
             # General case with full covariance matrix
-            data_cov = tf.linalg.inv(data_cov_inv)
-            cov_output = jacobian @ data_cov @ tf.transpose(jacobian)
+            # the following is equivalent to, but faster than: cov_output = jacobian @ tf.linalg.inv(data_cov_inv) @ tf.transpose(jacobian)
+            cov_output = jacobian @ tf.linalg.solve(
+                data_cov_inv, tf.transpose(jacobian)
+            )
 
         variances_output = tf.linalg.diag_part(cov_output)
 

--- a/combinetf2/physicsmodels/physicsmodel.py
+++ b/combinetf2/physicsmodels/physicsmodel.py
@@ -42,7 +42,10 @@ class PhysicsModel:
 
     # generic version which should not need to be overridden
     @tf.function
-    def get_data(self, data, data_cov_inv=None):
+    def get_data(self, *args, **kwargs):
+        return self._get_data(*args, **kwargs)
+
+    def _get_data(self, data, data_cov_inv=None):
         with tf.GradientTape() as t:
             t.watch(data)
             output = self.compute_flat(None, data)

--- a/combinetf2/tfhelpers.py
+++ b/combinetf2/tfhelpers.py
@@ -95,9 +95,9 @@ def edmval(grad, hess):
 
 def cond_number(hess):
     if is_on_gpu(hess):
-        tf.linalg.cond(hess)
+        return tf.linalg.cond(hess)
     else:
-        scipy_cond_number(hess.__array__())
+        return scipy_cond_number(hess.__array__())
 
 
 def segment_sum_along_axis(x, segment_ids, idx, num_segments):


### PR DESCRIPTION
For the chi2, use old logic of the covariance matrix calculation with a few improvements
- data covariance matrix is now taken into account
- Variance of beta0 is now computed automatically 

Separate functions for likelihood parts
- To compute only the necessary part of the likelihood, define separate functions `_compute_lc` and `_compute_lbeta` and use when appropriate

Fixes a bug in `combinetf2/tfhelpers.py` where return statements were missing in the function to compute the condition number

Smaller updates on plotting scrips
- replace `--noChisq` by `--chisq` to specify which chi2 value to be shown in the plot (from saturated test or linear chi2 calculation, none, or automatic). Automatic takes saturated if applicable and linear chi2 calculation otherwise. 
- added `--showVariations` which takes `upper` `lower` or `both` to show variations only in the upper, lower or in both panels
- Fixes a bug where variations were not correctly computed in the lower panel in case the lower panel shows the difference