### PR TITLE
Add blinding for pois and nois

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,7 +168,7 @@ jobs:
       - name: nominal fit
         run: >- 
           combinetf2_fit.py $COMBINETF2_OUTDIR/test_tensor.hdf5 -o $COMBINETF2_OUTDIR/
-          -t 0 --doImpacts --globalImpacts
+          -t 0 --unblind 'r:.*' --doImpacts --globalImpacts
           --saveHists --saveHistsPerProcess --computeHistErrors --computeHistErrorsPerProcess
           --computeHistCov --computeHistImpacts --computeVariations
           -m Basemodel
@@ -183,24 +183,30 @@ jobs:
           -m Normratio ch1 ch1 sig sig,bkg 'b:sum' 'b:2'
           -m tests.param_model.Param 'slope_signal' 1 0
 
+      - name: nominal fit blinded
+        run: >- 
+          combinetf2_fit.py $COMBINETF2_OUTDIR/test_tensor.hdf5 -o $COMBINETF2_OUTDIR/
+          -t 0 --postfix blinded --doImpacts --globalImpacts
+
       - name: sparse tensor fit 
         run: >- 
           combinetf2_fit.py $COMBINETF2_OUTDIR/test_tensor_sparse.hdf5 -o $COMBINETF2_OUTDIR/ --postfix sparse
           -t -0 --noBinByBinStat --doImpacts --globalImpacts --computeVariations
           --saveHists --saveHistsPerProcess --computeHistErrors --computeHistErrorsPerProcess
-          -m Project ch1 a -m Project ch1 b 
+          -m Project ch1 a -m Project ch1 b
 
       - name: pseudodata fit
         run: >- 
           combinetf2_fit.py $COMBINETF2_OUTDIR/test_tensor.hdf5 -o $COMBINETF2_OUTDIR/ --postfix pseudodata
-          -t 0 --pseudoData original --doImpacts --globalImpacts
+          -t 0 --pseudoData original --doImpacts --globalImpacts --unblind sig
 
       - name: chi2 fit
         run: >- 
           combinetf2_fit.py $COMBINETF2_OUTDIR/test_tensor.hdf5 -o $COMBINETF2_OUTDIR/ --postfix chi2
-          -t 0 --chisqFit --externalCovariance --doImpacts --globalImpacts 
+          -t 0 --unblind 'r:.*' --chisqFit --externalCovariance --doImpacts --globalImpacts 
           --saveHists --saveHistsPerProcess --computeHistErrors --computeHistErrorsPerProcess
-          -m Project ch1 a -m Project ch1 b 
+          -m Project ch1 a -m Project ch1 b
+
 
       - name: linearized solution
         run: >- 
@@ -229,6 +235,9 @@ jobs:
           echo "PLOT_DIR=${PLOT_DIR}" >> $GITHUB_ENV
 
       - uses: actions/checkout@v4
+
+      - name: print pulls & constraints blinded
+        run: combinetf2_print_pulls_and_constraints.py $COMBINETF2_OUTDIR/fitresults_blinded.hdf5 
 
       - name: print pulls & constraints
         run: combinetf2_print_pulls_and_constraints.py $COMBINETF2_OUTDIR/fitresults.hdf5 

--- a/bin/combinetf2_fit.py
+++ b/bin/combinetf2_fit.py
@@ -599,7 +599,6 @@ def main():
         fit_time = []
         for ifit in fits:
             ifitter.defaultassign()
-            ifitter.set_blinding_offsets(False)
 
             group = "results"
             if ifit == -1:

--- a/bin/combinetf2_fit.py
+++ b/bin/combinetf2_fit.py
@@ -289,8 +289,10 @@ def make_parser():
     )
     parser.add_argument(
         "--unblind",
-        action="store_true",
-        help="Unblind parameters of interest",
+        type=str,
+        default=[],
+        nargs="*",
+        help="Specify list of parameters or regex (leading by 'r:') to unblind matching parameters of interest. E.g. 'r:.*' to unblind all.",
     )
 
     return parser.parse_args()
@@ -597,7 +599,7 @@ def main():
         fit_time = []
         for ifit in fits:
             ifitter.defaultassign()
-            ifitter.do_blinding = False
+            ifitter.set_blinding(False)
 
             group = "results"
             if ifit == -1:
@@ -626,7 +628,7 @@ def main():
                 save_hists(args, models, ifitter, ws, prefit=True)
             prefit_time.append(time.time())
 
-            ifitter.do_blinding = ifit == 0 and not args.unblind
+            ifitter.set_blinding(ifit == 0, args.unblind)
             fit(args, ifitter, ws, dofit=ifit >= 0)
             fit_time.append(time.time())
 

--- a/bin/combinetf2_fit.py
+++ b/bin/combinetf2_fit.py
@@ -287,6 +287,11 @@ def make_parser():
         type=float,
         help="Assumed prefit uncertainty for unconstrained nuisances",
     )
+    parser.add_argument(
+        "--unblind",
+        action="store_true",
+        help="Unblind parameters of interest",
+    )
 
     return parser.parse_args()
 
@@ -592,6 +597,7 @@ def main():
         fit_time = []
         for ifit in fits:
             ifitter.defaultassign()
+            ifitter.do_blinding = False
 
             group = "results"
             if ifit == -1:
@@ -599,6 +605,7 @@ def main():
                 ifitter.nobs.assign(ifitter.expected_yield())
             if ifit == 0:
                 ifitter.nobs.assign(ifitter.indata.data_obs)
+
             elif ifit >= 1:
                 group += f"_toy{ifit}"
                 ifitter.toyassign(
@@ -619,6 +626,7 @@ def main():
                 save_hists(args, models, ifitter, ws, prefit=True)
             prefit_time.append(time.time())
 
+            ifitter.do_blinding = ifit == 0 and not args.unblind
             fit(args, ifitter, ws, dofit=ifit >= 0)
             fit_time.append(time.time())
 

--- a/bin/combinetf2_fit.py
+++ b/bin/combinetf2_fit.py
@@ -599,7 +599,7 @@ def main():
         fit_time = []
         for ifit in fits:
             ifitter.defaultassign()
-            ifitter.set_blinding(False)
+            ifitter.set_blinding_offsets(False)
 
             group = "results"
             if ifit == -1:
@@ -628,7 +628,7 @@ def main():
                 save_hists(args, models, ifitter, ws, prefit=True)
             prefit_time.append(time.time())
 
-            ifitter.set_blinding(ifit == 0, args.unblind)
+            ifitter.set_blinding_offsets(ifit == 0)
             fit(args, ifitter, ws, dofit=ifit >= 0)
             fit_time.append(time.time())
 

--- a/bin/combinetf2_plot_pulls_and_impacts.py
+++ b/bin/combinetf2_plot_pulls_and_impacts.py
@@ -468,8 +468,18 @@ def readFitInfoFromFile(
         else:
             pulls, pulls_prefit, constraints, constraints_prefit, impacts, labels = out
             if normalize:
-                idx = np.argwhere(labels == poi)
-                impacts /= impacts[idx].flatten()
+                imp, lab = io_tools.read_impacts_poi(
+                    fitresult,
+                    poi,
+                    True,
+                    pulls=False,
+                    asym=asym,
+                    global_impacts=global_impacts,
+                    add_total=True,
+                )
+
+                idx = np.argwhere(lab == "Total")
+                impacts /= imp[idx].flatten()
 
         if stat > 0 and "stat" in labels:
             idx = np.argwhere(labels == "stat")

--- a/combinetf2/fitter.py
+++ b/combinetf2/fitter.py
@@ -263,7 +263,7 @@ class Fitter:
 
         return poi
 
-    def get_theta(
+    def get_blinded_theta(
         self,
     ):
         theta = self.x[self.npoi :]
@@ -271,7 +271,7 @@ class Fitter:
             theta = self.apply_blinding_offsets_theta(theta)
         return theta
 
-    def get_poi(
+    def get_blinded_poi(
         self,
     ):
         xpoi = self.x[: self.npoi]
@@ -945,8 +945,8 @@ class Fitter:
     def _compute_yields_noBBB(self, compute_norm=False, full=True):
         # compute_norm: compute yields for each process, otherwise inclusive
         # full: compute yields inclduing masked channels
-        poi = self.get_poi()
-        theta = self.get_theta()
+        poi = self.get_blinded_poi()
+        theta = self.get_blinded_theta()
 
         rnorm = tf.concat(
             [poi, tf.ones([self.indata.nproc - poi.shape[0]], dtype=self.indata.dtype)],
@@ -1337,7 +1337,7 @@ class Fitter:
         return l
 
     def _compute_nll_components(self, profile=True):
-        theta = self.get_theta()
+        theta = self.x[self.npoi :]
 
         nexpfullcentral, _, beta = self._compute_yields_with_beta(
             profile=profile,

--- a/combinetf2/fitter.py
+++ b/combinetf2/fitter.py
@@ -335,6 +335,7 @@ class Fitter:
             self.beta0defaultassign()
             self.betadefaultassign()
         self.xdefaultassign()
+        self.set_blinding_offsets(False)
 
     def bayesassign(self):
         # FIXME use theta0 as the mean and constraintweight to scale the width

--- a/combinetf2/fitter.py
+++ b/combinetf2/fitter.py
@@ -233,13 +233,13 @@ class Fitter:
         # multiply offset to nois
         offsets = np.zeros(self.indata.nsyst, dtype=np.float64)
         for i in self.indata.noigroupidxs:
-            param = self.indata.noigroups[i]
+            param = self.indata.systs[i]
             if param in unblind_parameters:
                 continue
             logger.debug(f"Blind parameter {param}")
             value = deterministic_random_from_string(param)
             offsets[i] = value
-        self.__blinding_offsets_theta = tf.constant(offsets, dtype=self.indata.dtype)
+        self._blinding_offsets_theta = tf.constant(offsets, dtype=self.indata.dtype)
 
         # add offset to pois
         offsets = np.ones(self.npoi, dtype=np.float64)
@@ -250,12 +250,12 @@ class Fitter:
             logger.debug(f"Blind signal strength modifier for {param}")
             value = deterministic_random_from_string(param)
             offsets[i] = np.exp(value)
-        self.__blinding_offsets_poi = tf.constant(offsets, dtype=self.indata.dtype)
+        self._blinding_offsets_poi = tf.constant(offsets, dtype=self.indata.dtype)
 
     def get_blinded_theta(self):
         theta = self.x[self.npoi :]
         if self._blind:
-            theta = theta + self.__blinding_offsets_theta
+            theta = theta + self._blinding_offsets_theta
         return theta
 
     def get_blinded_poi(self):
@@ -265,7 +265,7 @@ class Fitter:
         else:
             poi = tf.square(xpoi)
         if self._blind:
-            poi = poi * self.__blinding_offsets_poi
+            poi = poi * self._blinding_offsets_poi
         return poi
 
     def _default_beta0(self):

--- a/combinetf2/fitter.py
+++ b/combinetf2/fitter.py
@@ -29,7 +29,7 @@ class Fitter:
         self.binByBinStat = not options.noBinByBinStat
         self.systgroupsfull = self.indata.systgroups.tolist()
         self.systgroupsfull.append("stat")
-        self.blind = False
+        self._blind = False
         if self.binByBinStat:
             self.systgroupsfull.append("binByBinStat")
 
@@ -254,7 +254,7 @@ class Fitter:
 
     def get_blinded_theta(self):
         theta = self.x[self.npoi :]
-        if self.blind:
+        if self._blind:
             theta = theta + self.__blinding_offsets_theta
         return theta
 
@@ -264,7 +264,7 @@ class Fitter:
             poi = xpoi
         else:
             poi = tf.square(xpoi)
-        if self.blind:
+        if self._blind:
             poi = poi * self.__blinding_offsets_poi
         return poi
 

--- a/combinetf2/physicsmodels/helpers.py
+++ b/combinetf2/physicsmodels/helpers.py
@@ -155,10 +155,10 @@ class Term:
         h = hist.Hist(*channel_axes)
         if self.selections:
             for k, s in selections.items():
-                if s.step is None:
-                    h = h[{k: s}]
-                else:
+                if isinstance(s, slice) and s.step is not None:
                     h = h[{k: slice(s.start, s.stop, hist.rebin(s.step))}]
+                else:
+                    h = h[{k: s}]
 
         self.segment_ids = {}
         self.num_segments = {}


### PR DESCRIPTION
- Option `--unblind <list of parameters or regexs>` added to combinetf2_fit to unblind POIs and NOIs, which are now blinded by default when fitting the data (via -t 0).
- For each POI and NOI a deterministic seed is chosen based on the string of the name of the signal (in case of NOI) or systematic (in case of NOI). This ensures the same offset is used in different fit configurations.
- The random offset is chosen from a normal distribution of mean 0 and std 5
- The offset is then added on x when computing the event yields, as it was done for combinetf1. 
- In the fit, the offset is subtracted to ensure the same initial values as if the fit would not be blinded. 