### PR TITLE
Update command line arguments in combineft2_fit.py

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,7 +168,7 @@ jobs:
       - name: nominal fit
         run: >- 
           combinetf2_fit.py $COMBINETF2_OUTDIR/test_tensor.hdf5 -o $COMBINETF2_OUTDIR/
-          -t 0 --unblind 'r:.*' --doImpacts --globalImpacts
+          -t 0 --unblind '*' --doImpacts --globalImpacts
           --saveHists --saveHistsPerProcess --computeHistErrors --computeHistErrorsPerProcess
           --computeHistCov --computeHistImpacts --computeVariations
           -m Basemodel
@@ -203,7 +203,7 @@ jobs:
       - name: chi2 fit
         run: >- 
           combinetf2_fit.py $COMBINETF2_OUTDIR/test_tensor.hdf5 -o $COMBINETF2_OUTDIR/ --postfix chi2
-          -t 0 --unblind 'r:.*' --chisqFit --externalCovariance --doImpacts --globalImpacts 
+          -t 0 --unblind '*' --chisqFit --externalCovariance --doImpacts --globalImpacts 
           --saveHists --saveHistsPerProcess --computeHistErrors --computeHistErrorsPerProcess
           -m Project ch1 a -m Project ch1 b
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,7 +168,7 @@ jobs:
       - name: nominal fit
         run: >- 
           combinetf2_fit.py $COMBINETF2_OUTDIR/test_tensor.hdf5 -o $COMBINETF2_OUTDIR/
-          -t 0 --unblind '*' --doImpacts --globalImpacts
+          -t 0 --unblind '.*' --doImpacts --globalImpacts
           --saveHists --saveHistsPerProcess --computeHistErrors --computeHistErrorsPerProcess
           --computeHistCov --computeHistImpacts --computeVariations
           -m Basemodel
@@ -198,12 +198,12 @@ jobs:
       - name: pseudodata fit
         run: >- 
           combinetf2_fit.py $COMBINETF2_OUTDIR/test_tensor.hdf5 -o $COMBINETF2_OUTDIR/ --postfix pseudodata
-          -t 0 --pseudoData original --doImpacts --globalImpacts --unblind sig
+          -t 0 --pseudoData original --doImpacts --globalImpacts --unblind ^sig$
 
       - name: chi2 fit
         run: >- 
           combinetf2_fit.py $COMBINETF2_OUTDIR/test_tensor.hdf5 -o $COMBINETF2_OUTDIR/ --postfix chi2
-          -t 0 --unblind '*' --chisqFit --externalCovariance --doImpacts --globalImpacts 
+          -t 0 --unblind '.*' --chisqFit --externalCovariance --doImpacts --globalImpacts 
           --saveHists --saveHistsPerProcess --computeHistErrors --computeHistErrorsPerProcess
           -m Project ch1 a -m Project ch1 b
 

--- a/bin/combinetf2_fit.py
+++ b/bin/combinetf2_fit.py
@@ -556,8 +556,8 @@ def main():
     ifitter = fitter.Fitter(indata, args)
 
     # physics models for observables and transformations
-    if len(args.physicsModel) == 0:
-        # if no model is explicitly added, fall back to Basemodel
+    if len(args.physicsModel) == 0 and args.saveHists:
+        # if no model is explicitly added and --saveHists is specified, fall back to Basemodel
         args.physicsModel = [["Basemodel"]]
     models = []
     for margs in args.physicsModel:

--- a/bin/combinetf2_fit.py
+++ b/bin/combinetf2_fit.py
@@ -166,6 +166,12 @@ def make_parser():
         help="use prefit uncertainty to define scan range",
     )
     parser.add_argument(
+        "--noHessian",
+        default=False,
+        action="store_true",
+        help="Don't compute the hessian of parameters",
+    )
+    parser.add_argument(
         "--saveHists",
         default=False,
         action="store_true",
@@ -428,32 +434,34 @@ def fit(args, fitter, ws, dofit=True):
 
         # compute the covariance matrix and estimated distance to minimum
 
-        val, grad, hess = fitter.loss_val_grad_hess()
+        if not args.noHessian:
 
-        edmval, cov = edmval_cov(grad, hess)
+            val, grad, hess = fitter.loss_val_grad_hess()
 
-        logger.info(f"edmval: {edmval}")
+            edmval, cov = edmval_cov(grad, hess)
 
-        fitter.cov.assign(cov)
+            logger.info(f"edmval: {edmval}")
 
-        del cov
+            fitter.cov.assign(cov)
 
-        if fitter.binByBinStat and fitter.diagnostics:
-            # This is the estimated distance to minimum with respect to variations of
-            # the implicit binByBinStat nuisances beta at fixed parameter values.
-            # It should be near-zero by construction as long as the analytic profiling is
-            # correct
-            _, gradbeta, hessbeta = fitter.loss_val_grad_hess_beta()
-            edmvalbeta, covbeta = edmval_cov(gradbeta, hessbeta)
-            logger.info(f"edmvalbeta: {edmvalbeta}")
+            del cov
 
-        if args.doImpacts:
-            ws.add_impacts_hists(*fitter.impacts_parms(hess))
+            if fitter.binByBinStat and fitter.diagnostics:
+                # This is the estimated distance to minimum with respect to variations of
+                # the implicit binByBinStat nuisances beta at fixed parameter values.
+                # It should be near-zero by construction as long as the analytic profiling is
+                # correct
+                _, gradbeta, hessbeta = fitter.loss_val_grad_hess_beta()
+                edmvalbeta, covbeta = edmval_cov(gradbeta, hessbeta)
+                logger.info(f"edmvalbeta: {edmvalbeta}")
 
-        del hess
+            if args.doImpacts:
+                ws.add_impacts_hists(*fitter.impacts_parms(hess))
 
-        if args.globalImpacts:
-            ws.add_global_impacts_hists(*fitter.global_impacts_parms())
+            del hess
+
+            if args.globalImpacts:
+                ws.add_global_impacts_hists(*fitter.global_impacts_parms())
 
     nllvalfull = fitter.full_nll().numpy()
     satnllvalfull, ndfsat = fitter.saturated_nll()
@@ -473,11 +481,12 @@ def fit(args, fitter, ws, dofit=True):
 
     ws.add_parms_hist(
         values=fitter.x,
-        variances=tf.linalg.diag_part(fitter.cov),
+        variances=tf.linalg.diag_part(fitter.cov) if not args.noHessian else None,
         hist_name="parms",
     )
 
-    ws.add_cov_hist(fitter.cov)
+    if not args.noHessian:
+        ws.add_cov_hist(fitter.cov)
 
     if args.scan is not None:
         parms = np.array(fitter.parms).astype(str) if len(args.scan) == 0 else args.scan
@@ -548,6 +557,9 @@ def main():
 
     if args.eager:
         tf.config.run_functions_eagerly(True)
+
+    if args.noHessian and args.doImpacts:
+        raise Exception('option "--noHessian" only works without "--doImpacts"')
 
     global logger
     logger = logging.setup_logger(__file__, args.verbose, args.noColorLogger)

--- a/bin/combinetf2_fit.py
+++ b/bin/combinetf2_fit.py
@@ -292,7 +292,7 @@ def make_parser():
         type=str,
         default=[],
         nargs="*",
-        help="Specify list of parameters or regex (leading by 'r:') to unblind matching parameters of interest. E.g. 'r:.*' to unblind all.",
+        help="Specify list of parameters to unblind matching parameters of interest, allows shell-style wildcards. E.g. 'param' to unblind param or '*' to unblind all.",
     )
 
     return parser.parse_args()

--- a/bin/combinetf2_fit.py
+++ b/bin/combinetf2_fit.py
@@ -298,7 +298,7 @@ def make_parser():
         type=str,
         default=[],
         nargs="*",
-        help="Specify list of parameters to unblind matching parameters of interest, allows shell-style wildcards. E.g. 'param' to unblind param or '*' to unblind all.",
+        help="Specify list of regex to unblind matching parameters of interest. E.g. use '^signal$' to unblind a parameter named signal or '.*' to unblind all.",
     )
 
     return parser.parse_args()

--- a/combinetf2/fitter.py
+++ b/combinetf2/fitter.py
@@ -1,5 +1,5 @@
-import fnmatch
 import hashlib
+import re
 
 import numpy as np
 import scipy
@@ -196,13 +196,14 @@ class Fitter:
 
     def init_blinding_values(self, unblind_parameter_expressions=[]):
         # Find parameters that match any regex
+        compiled_expressions = [
+            re.compile(expr) for expr in unblind_parameter_expressions
+        ]
+
         unblind_parameters = [
             s
             for s in [*self.indata.signals, *self.indata.noigroups]
-            if any(
-                fnmatch.fnmatch(s.decode(), expr)
-                for expr in unblind_parameter_expressions
-            )
+            if any(regex.match(s.decode()) for regex in compiled_expressions)
         ]
 
         # check if dataset is an integer (i.e. if it is real data or not) and use this to choose the random seed

--- a/combinetf2/fitter.py
+++ b/combinetf2/fitter.py
@@ -1,5 +1,5 @@
+import fnmatch
 import hashlib
-import re
 
 import numpy as np
 import scipy
@@ -195,23 +195,14 @@ class Fitter:
         )
 
     def init_blinding_values(self, unblind_parameter_expressions=[]):
-        def compile_patterns(patterns):
-            compiled = []
-            for p in patterns:
-                if p.startswith("r:"):
-                    # Treat as regex, remove prefix
-                    compiled.append(re.compile(p[2:]))
-                else:
-                    # Treat as exact string match
-                    compiled.append(re.compile(rf"^{re.escape(p)}$"))
-            return compiled
-
         # Find parameters that match any regex
-        compiled_regexes = compile_patterns(unblind_parameter_expressions)
         unblind_parameters = [
             s
-            for s in [*self.indata.procs, *self.indata.noigroups]
-            if any(regex.search(s.decode()) for regex in compiled_regexes)
+            for s in [*self.indata.signals, *self.indata.noigroups]
+            if any(
+                fnmatch.fnmatch(s.decode(), expr)
+                for expr in unblind_parameter_expressions
+            )
         ]
 
         # check if dataset is an integer (i.e. if it is real data or not) and use this to choose the random seed


### PR DESCRIPTION
- In combinetf2_fit.py set fallback 'Basemodel' only if '--saveHists' is specified to allow running without a physics model
- Add option to skip computation of hessian
- Use pure regex to specify parameters to unblind